### PR TITLE
Use Rails route names instead of hard-coded urls

### DIFF
--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -42,21 +42,27 @@ module Madmin
       end
 
       def index_path(options = {})
-        path = "/madmin/#{model.model_name.collection}"
-        path += "?#{options.to_param}" if options.any?
-        path
+        route_name = "madmin_#{model.model_name.collection}_path"
+
+        url_helpers.send(route_name, options)
       end
 
       def new_path
-        "/madmin/#{model.model_name.collection}/new"
+        route_name = "new_madmin_#{model.model_name.singular}_path"
+
+        url_helpers.send(route_name)
       end
 
       def show_path(record)
-        "/madmin/#{model.model_name.collection}/#{record.to_param}"
+        route_name = "madmin_#{model.model_name.singular}_path"
+
+        url_helpers.send(route_name, record.to_param)
       end
 
       def edit_path(record)
-        "/madmin/#{model.model_name.collection}/#{record.to_param}/edit"
+        route_name = "edit_madmin_#{model.model_name.singular}_path"
+
+        url_helpers.send(route_name, record.to_param)
       end
 
       def param_key
@@ -178,6 +184,10 @@ module Madmin
         else
           :belongs_to
         end
+      end
+
+      def url_helpers
+        @url_helpers ||= Rails.application.routes.url_helpers
       end
     end
   end

--- a/test/madmin/resource_path_test.rb
+++ b/test/madmin/resource_path_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ResourcePathTest < ActiveSupport::TestCase
+  test "resource has an index path" do
+    assert_equal "/madmin/posts", PostResource.index_path
+  end
+
+  test "resource has an index path with query params if given any arguments" do
+    assert_equal "/madmin/posts?q=post&t=test", PostResource.index_path(q: "post", t: "test")
+  end
+
+  test "resource has a new path" do
+    assert_equal "/madmin/posts/new", PostResource.new_path
+  end
+
+  test "resource has a show path" do
+    post = posts(:one)
+    assert_equal "/madmin/posts/#{post.id}", PostResource.show_path(post.id)
+  end
+
+  test "resource has an edit path" do
+    post = posts(:one)
+    assert_equal "/madmin/posts/#{post.id}/edit", PostResource.edit_path(post.id)
+  end
+end


### PR DESCRIPTION
Closes https://github.com/excid3/madmin/issues/40

This uses `Rails.application.routes.url_helpers` to generate the resource navigation urls's instead of hard-coded values. 