### PR TITLE
Allow for custom display_name

### DIFF
--- a/lib/generators/madmin/resource/templates/resource.rb.tt
+++ b/lib/generators/madmin/resource/templates/resource.rb.tt
@@ -8,4 +8,9 @@ class <%= class_name %>Resource < Madmin::Resource
 <% associations.each do |association_name| -%>
   attribute :<%= association_name %>
 <% end -%>
+
+  # Uncomment this to customize the display name of records in the admin area.
+  # def self.display_name(record)
+  #   record.name
+  # end
 end

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -3,10 +3,11 @@ module Madmin
     class BelongsTo < Field
       def options_for_select(record)
         association = record.class.reflect_on_association(attribute_name)
-
         klass = association.klass
+        resource = nil
         klass.all.map do |r|
-          ["#{klass.name} ##{r.id}", r.id]
+          resource ||= Madmin.resource_for(r)
+          [resource.display_name(r), r.id]
         end
       end
 

--- a/lib/madmin/fields/has_many.rb
+++ b/lib/madmin/fields/has_many.rb
@@ -3,10 +3,11 @@ module Madmin
     class HasMany < Field
       def options_for_select(record)
         association = record.class.reflect_on_association(attribute_name)
-
         klass = association.klass
+        resource = nil
         klass.all.map do |r|
-          ["#{klass.name} ##{r.id}", r.id]
+          resource ||= Madmin.resource_for(r)
+          [resource.display_name(r), r.id]
         end
       end
 

--- a/test/dummy/app/madmin/resources/user_resource.rb
+++ b/test/dummy/app/madmin/resources/user_resource.rb
@@ -13,4 +13,9 @@ class UserResource < Madmin::Resource
   attribute :posts
   attribute :comments
   attribute :habtms
+
+  # Uncomment this to customize the display name of records in the admin area.
+  def self.display_name(record)
+    "#{record.first_name} #{record.last_name}"
+  end
 end

--- a/test/dummy/test/fixtures/users.yml
+++ b/test/dummy/test/fixtures/users.yml
@@ -1,8 +1,8 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  first_name: MyString
-  last_name: MyString
+  first_name: Chris
+  last_name: Oliver
   birthday: 2020-09-10
 
 two:

--- a/test/madmin/resource_display_name_test.rb
+++ b/test/madmin/resource_display_name_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class ResourceDisplayNameTest < ActiveSupport::TestCase
+  test "resource has a custom display name" do
+    resource = users(:one)
+
+    assert_equal "Chris Oliver", UserResource.display_name(resource)
+  end
+
+  test "resource uses default display name" do
+    resource = posts(:one)
+
+    assert_equal "Post ##{resource.id}", PostResource.display_name(resource)
+  end
+end


### PR DESCRIPTION
I'm creating a draft PR here because I'm not sure whether this is the right approach or not. That's also why I didn't add any tests yet.

In admin panel I'm building right now, the admins should be able to easily see the name of the relating record. Right now the display name is `User #id`. This PR allows this name to be changed by adding a `display_name` method to the `User` model. I'm a little unsure if it's a good idea to add this logic to the "main" app, or if we should keep this inside the Madmin logic.