### PR TITLE
Separate routes file for Rails 6.1 and up

### DIFF
--- a/lib/generators/madmin/install/install_generator.rb
+++ b/lib/generators/madmin/install/install_generator.rb
@@ -16,8 +16,13 @@ module Madmin
       end
 
       def generate_routes
+        if rails6_1_and_up?
+          route "draw :madmin", file: ROUTES_FILE[:default]
+          template("routes.rb.tt", "config/routes/madmin.rb")
+        end
+
         if route_namespace_exists?
-          route "root to: \"dashboard#show\"", indentation: 4, sentinel: /namespace :madmin do\s*\n/m
+          route "root to: \"dashboard#show\"", indentation: separated_routes_file? ? 2 : 4, sentinel: /namespace :madmin do\s*\n/m
         else
           route "root to: \"dashboard#show\"", namespace: [:madmin]
         end

--- a/lib/generators/madmin/install/templates/routes.rb.tt
+++ b/lib/generators/madmin/install/templates/routes.rb.tt
@@ -1,0 +1,3 @@
+# Below are the routes for madmin
+namespace :madmin do
+end

--- a/lib/generators/madmin/resource/resource_generator.rb
+++ b/lib/generators/madmin/resource/resource_generator.rb
@@ -20,7 +20,7 @@ module Madmin
 
       def generate_route
         if route_namespace_exists?
-          route "resources :#{plural_name}", namespace: class_path, indentation: 4, sentinel: /namespace :madmin do\s*\n/m
+          route "resources :#{plural_name}", namespace: class_path, indentation: separated_routes_file? ? 2 : 4, sentinel: /namespace :madmin do\s*\n/m
         else
           route "resources :#{plural_name}", namespace: [:madmin] + class_path
         end

--- a/lib/madmin/generator_helpers.rb
+++ b/lib/madmin/generator_helpers.rb
@@ -1,24 +1,30 @@
 module Madmin
   module GeneratorHelpers
+    ROUTES_FILE = {default: "config/routes.rb", separated: "config/routes/madmin.rb"}.freeze
+
     def call_generator(generator, *args)
       Rails::Generators.invoke(generator, args, generator_options)
     end
 
     def route_namespace_exists?
-      File.readlines(Rails.root.join("config/routes.rb")).grep(/namespace :madmin/).size > 0
+      File.readlines(Rails.root.join(default_routes_file)).grep(/namespace :madmin/).size > 0
+    end
+
+    def rails6_1_and_up?
+      Gem.loaded_specs["rails"].version >= Gem::Version.new(6.1)
     end
 
     # Method copied from Rails 6.1 master
-    def route(routing_code, namespace: nil, sentinel: nil, indentation: 2)
+    def route(routing_code, namespace: nil, sentinel: nil, indentation: 2, file: default_routes_file)
       routing_code = Array(namespace).reverse.reduce(routing_code) { |code, ns|
         "namespace :#{ns} do\n#{indent(code, 2)}\nend"
       }
 
       log :route, routing_code
-      sentinel ||= /\.routes\.draw do\s*\n/m
+      sentinel ||= default_sentinel(file)
 
       in_root do
-        inject_into_file "config/routes.rb", optimize_indentation(routing_code, indentation), after: sentinel, verbose: false, force: false
+        inject_into_file file, optimize_indentation(routing_code, indentation), after: sentinel, verbose: false, force: false
       end
     end
 
@@ -29,6 +35,18 @@ module Madmin
     end
 
     private
+
+    def separated_routes_file?
+      default_routes_file.eql?(ROUTES_FILE[:separated])
+    end
+
+    def default_sentinel(file)
+      file.eql?(ROUTES_FILE[:default]) ? /\.routes\.draw do\s*\n/m : /namespace :madmin do\s*\n/m
+    end
+
+    def default_routes_file
+      rails6_1_and_up? ? ROUTES_FILE[:separated] : ROUTES_FILE[:default]
+    end
 
     def generator_options
       {behavior: behavior}


### PR DESCRIPTION
Hello @excid3,

I've opened this PR to resolve #66. This PR adds routes into:
- config/routes/madmin.rb for Rails >= 6.1
- config/routes.rb for Rails < 6.1
Please take a look when you have time, and let me know if this requires additional work. 

Thanks! 🙏😄
