### PR TITLE
Update the pagy dependency of madmin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     madmin (1.2.0)
-      pagy (>= 3.5, < 4.0)
+      pagy (>= 3.5, < 5.0)
       rails (>= 6.0.3)
 
 GEM

--- a/gemfiles/rails_6.gemfile.lock
+++ b/gemfiles/rails_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     madmin (1.2.0)
-      pagy (>= 3.5, < 4.0)
+      pagy (>= 3.5, < 5.0)
       rails (>= 6.0.3)
 
 GEM
@@ -91,11 +91,15 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     mysql2 (0.5.3)
     name_of_person (1.1.1)
       activesupport (>= 5.2.0)
     nio4r (2.5.7)
+    nokogiri (1.11.4)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.4-x86_64-linux)
@@ -207,6 +211,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     madmin (1.2.0)
-      pagy (>= 3.5, < 4.0)
+      pagy (>= 3.5, < 5.0)
       rails (>= 6.0.3)
 
 GEM
@@ -210,6 +210,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/gemfiles/rails_master.gemfile.lock
+++ b/gemfiles/rails_master.gemfile.lock
@@ -87,7 +87,7 @@ PATH
   remote: ..
   specs:
     madmin (1.2.0)
-      pagy (>= 3.5, < 4.0)
+      pagy (>= 3.5, < 5.0)
       rails (>= 6.0.3)
 
 GEM
@@ -125,11 +125,15 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     mysql2 (0.5.3)
     name_of_person (1.1.1)
       activesupport (>= 5.2.0)
     nio4r (2.5.7)
+    nokogiri (1.11.4)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.11.4-x86_64-linux)
@@ -219,6 +223,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/madmin.gemspec
+++ b/madmin.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "rails", ">= 6.0.3"
-  spec.add_dependency "pagy", ">= 3.5", "< 4.0"
+  spec.add_dependency "pagy", ">= 4.0"
 end

--- a/madmin.gemspec
+++ b/madmin.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "rails", ">= 6.0.3"
-  spec.add_dependency "pagy", ">= 4.0"
+  spec.add_dependency "pagy", ">= 3.5", "< 5.0"
 end


### PR DESCRIPTION
madmin and pagy 3+ are not working with ruby 3+, so I submit a pull request to update the pagy dependency of madmin. The reasons for updating are as below:

- As [pagy](https://github.com/ddnexus/pagy#new-in-48) mentioned that the pagy 4+ is for ruby 2.5+ and the pagy 3+ is for ruby <2.5. So we should use pagy 4+ because madmin required ruby version  2.5+.
- The pagy 3+ is not working with ruby 3+, we need upgrade pagy to 4+ in order to use ruby 3+.

<img width="886" alt="image" src="https://user-images.githubusercontent.com/7600503/127148946-6f471847-1b16-4117-b6e3-98d6ae58d68b.png">

<img width="812" alt="image" src="https://user-images.githubusercontent.com/7600503/127148709-0c1aa98c-fef7-4505-ba9d-4cf9a0a873f6.png">
