### PR TITLE
Show * for required fields

### DIFF
--- a/app/views/madmin/fields/attachment/_form.html.erb
+++ b/app/views/madmin/fields/attachment/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.file_field field.to_param %>

--- a/app/views/madmin/fields/attachments/_form.html.erb
+++ b/app/views/madmin/fields/attachments/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.file_field field.attribute_name, multiple: true %>

--- a/app/views/madmin/fields/belongs_to/_form.html.erb
+++ b/app/views/madmin/fields/belongs_to/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.select field.to_param, field.options_for_select(record), { prompt: true }, { class: "form-select", data: { controller: "select", select_url_value: field.index_path } } %>

--- a/app/views/madmin/fields/boolean/_form.html.erb
+++ b/app/views/madmin/fields/boolean/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.check_box field.attribute_name, class: "form-input" %>

--- a/app/views/madmin/fields/date/_form.html.erb
+++ b/app/views/madmin/fields/date/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.text_field field.attribute_name, { class: "form-select", data: { controller: "flatpickr" } } %>

--- a/app/views/madmin/fields/date_time/_form.html.erb
+++ b/app/views/madmin/fields/date_time/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.text_field field.attribute_name, data: { controller: "flatpickr", flatpickr_enable_time: true } %>

--- a/app/views/madmin/fields/decimal/_form.html.erb
+++ b/app/views/madmin/fields/decimal/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.number_field field.attribute_name, step: :any, class: "form-input" %>

--- a/app/views/madmin/fields/enum/_form.html.erb
+++ b/app/views/madmin/fields/enum/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.select field.attribute_name, field.options_for_select(record), { prompt: true }, { class: "form-select", data: { controller: "select" } } %>

--- a/app/views/madmin/fields/float/_form.html.erb
+++ b/app/views/madmin/fields/float/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.number_field field.attribute_name, step: :any, class: "form-input" %>

--- a/app/views/madmin/fields/has_many/_form.html.erb
+++ b/app/views/madmin/fields/has_many/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.select "#{field.attribute_name.to_s.singularize}_ids", field.options_for_select(record), { prompt: true }, { multiple: true, class: "form-select", data: { controller: "select", select_url_value: field.index_path } } %>

--- a/app/views/madmin/fields/has_one/_form.html.erb
+++ b/app/views/madmin/fields/has_one/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= field.value(record) %>

--- a/app/views/madmin/fields/integer/_form.html.erb
+++ b/app/views/madmin/fields/integer/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.number_field field.attribute_name, class: "form-input" %>

--- a/app/views/madmin/fields/json/_form.html.erb
+++ b/app/views/madmin/fields/json/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.text_area field.attribute_name, class: "form-input" %>

--- a/app/views/madmin/fields/nested_has_many/_form.html.erb
+++ b/app/views/madmin/fields/nested_has_many/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0" %>
+<div class="block md:inline-block w-32 flex-shrink-0">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 
 <div class="container space-y-8" data-controller="nested-form">
   <template data-target="nested-form.template">

--- a/app/views/madmin/fields/password/_form.html.erb
+++ b/app/views/madmin/fields/password/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.password_field field.attribute_name, class: "form-input" %>

--- a/app/views/madmin/fields/polymorphic/_form.html.erb
+++ b/app/views/madmin/fields/polymorphic/_form.html.erb
@@ -1,5 +1,7 @@
 <%= form.fields_for field.attribute_name do |pf| %>
-  <%= pf.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+  <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+    <%= render "madmin/shared/label", form: pf, field: field %>
+  </div>
   <%= pf.select :value, field.options_for_select(record).map(&:to_global_id), { selected: field.value(record)&.to_global_id, prompt: true }, { class: "form-select", data: { controller: "slimselect" } } %>
   <%= pf.hidden_field :type, value: "polymorphic" %>
 <% end %>

--- a/app/views/madmin/fields/rich_text/_form.html.erb
+++ b/app/views/madmin/fields/rich_text/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <div class="flex-1">
   <%= form.rich_text_area field.attribute_name, class: "form-input block" %>
 </div>

--- a/app/views/madmin/fields/string/_form.html.erb
+++ b/app/views/madmin/fields/string/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block md:w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.text_field field.attribute_name, class: "form-input" %>

--- a/app/views/madmin/fields/text/_form.html.erb
+++ b/app/views/madmin/fields/text/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.text_area field.attribute_name, class: "form-input" %>

--- a/app/views/madmin/fields/time/_form.html.erb
+++ b/app/views/madmin/fields/time/_form.html.erb
@@ -1,2 +1,4 @@
-<%= form.label field.attribute_name, class: "block md:inline-block w-32 flex-shrink-0 text-gray-700" %>
+<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+  <%= render "madmin/shared/label", form: form, field: field %>
+</div>
 <%= form.time_select field.attribute_name, {}, { class: "form-select" } %>

--- a/app/views/madmin/shared/_label.html.erb
+++ b/app/views/madmin/shared/_label.html.erb
@@ -1,0 +1,4 @@
+<%= form.label field.attribute_name %>
+<% if field.required? %>
+  <span class="text-red-500">*</span>
+<% end %>

--- a/test/madmin/field_test.rb
+++ b/test/madmin/field_test.rb
@@ -16,9 +16,4 @@ class Madmin::FieldTest < ActiveSupport::TestCase
     attribute = UserResource.attributes.find { |a| a[:name] == :created_at }
     refute attribute[:field].searchable?
   end
-
-  test "required?" do
-    attribute = UserResource.attributes.find { |a| a[:name] == :title }
-    refute attribute[:field].required?
-  end
 end

--- a/test/madmin/field_test.rb
+++ b/test/madmin/field_test.rb
@@ -16,4 +16,9 @@ class Madmin::FieldTest < ActiveSupport::TestCase
     attribute = UserResource.attributes.find { |a| a[:name] == :created_at }
     refute attribute[:field].searchable?
   end
+
+  test "required?" do
+    attribute = UserResource.attributes.find { |a| a[:name] == :title }
+    refute attribute[:field].required?
+  end
 end


### PR DESCRIPTION
#19 

I know you had already started parts of this - but hopefully you never finished it :)

This adds a red `*` after the label name if the field is required. Right now I have created a shared `_label` partial which might be overkill/less-customizable and it might be more desirable to have duplicate code in each of the `_form` partials?