### PR TITLE
Fix pagy error when search at non-first page

### DIFF
--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -3,6 +3,7 @@
 
   <div class="flex-grow flex md:justify-end gap-4">
     <form class="flex items-center gap-2 relative">
+      <%= hidden_field_tag :page, params[:page], value: 1, class: "hidden" %>
       <%= search_field_tag :q, params[:q], placeholder: "Search", class: "rounded-full px-4 focus:bg-white focus:border-indigo-500" %>
       <%= link_to clear_search_params, class: "absolute top-1/2 right-3 text-gray-500 bg-white transform -translate-y-1/2" do %>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">


### PR DESCRIPTION
I ran into this error when search at page 12, but the search result only has two page (or less).

![image](https://user-images.githubusercontent.com/25289725/128629113-673ff44e-536b-48ef-82b3-eaee17c8a1ff.png)

So I think we can add a hidden search field to override current page if we are not at page 1.

This fix worked for me, but I'm not sure this is the best way to achieve it.