### PR TITLE
Fix order not work when model have default scope

### DIFF
--- a/app/controllers/madmin/resource_controller.rb
+++ b/app/controllers/madmin/resource_controller.rb
@@ -71,7 +71,7 @@ module Madmin
     def scoped_resources
       resources = resource.model.send(valid_scope)
       resources = Madmin::Search.new(resources, resource, search_term).run
-      resources.order(sort_column => sort_direction)
+      resources.reorder(sort_column => sort_direction)
     end
 
     def valid_scope


### PR DESCRIPTION
If the model already has a default_scope order, multiple sorting conditions may not work as expected.
Using reorder to override default order.