### PR TITLE
WIP: Bulk delete

### DIFF
--- a/app/controllers/madmin/bulk_controller.rb
+++ b/app/controllers/madmin/bulk_controller.rb
@@ -1,0 +1,27 @@
+module Madmin
+  class BulkController < ApplicationController
+    # Assign current_user for paper_trail gem
+    before_action :set_paper_trail_whodunnit, if: -> { respond_to?(:set_paper_trail_whodunnit, true) }
+
+    def destroy
+      if params[:all]
+        @records = resource.model.destroy_all
+      else
+        @records = resource.model.where(id: params[:ids]).destroy_all
+      end
+
+      redirect_to resource.index_path
+    end
+
+    private
+
+    def resource
+      @resource ||= resource_name.constantize
+    end
+    helper_method :resource
+
+    def resource_name
+      "#{params[:resource].singularize}_resource".classify
+    end
+  end
+end

--- a/app/controllers/madmin/bulk_controller.rb
+++ b/app/controllers/madmin/bulk_controller.rb
@@ -4,11 +4,7 @@ module Madmin
     before_action :set_paper_trail_whodunnit, if: -> { respond_to?(:set_paper_trail_whodunnit, true) }
 
     def destroy
-      if params[:all]
-        @records = resource.model.destroy_all
-      else
-        @records = resource.model.where(id: params[:ids]).destroy_all
-      end
+      @records = resource.model.where(id: params[:ids]).destroy_all
 
       redirect_to resource.index_path
     end

--- a/app/controllers/madmin/bulk_controller.rb
+++ b/app/controllers/madmin/bulk_controller.rb
@@ -6,7 +6,7 @@ module Madmin
     def destroy
       @records = resource.model.where(id: params[:ids]).destroy_all
 
-      redirect_to resource.index_path
+      head :ok
     end
 
     private

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -161,11 +161,7 @@
         if (!this.checked.length) return;
 
         let data = new FormData()
-        if (this.checked.length == this.checkboxTargets.length) {
-          data.append("all", true)
-        } else {
-          this.checked.forEach((checkbox) => data.append("ids[]", checkbox.value))
-        }
+        this.checked.forEach((checkbox) => data.append("ids[]", checkbox.value))
 
         Rails.ajax({
           url: `/madmin/bulk/${this.resourcesValue}`,

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -6,6 +6,7 @@
   import { Application, Controller } from 'https://cdn.skypack.dev/stimulus'
   const application = Application.start()
 
+  import { destroy } from "https://cdn.skypack.dev/@rails/request.js"
   import { Dropdown } from "https://cdn.skypack.dev/tailwindcss-stimulus-components"
   application.register("dropdown", Dropdown)
 
@@ -155,7 +156,7 @@
         return this.checkboxTargets.filter(checkbox => checkbox.checked)
       }
 
-      destroy(event) {
+      async destroy(event) {
         event.preventDefault()
 
         if (!this.checked.length) return;
@@ -163,11 +164,7 @@
         let data = new FormData()
         this.checked.forEach((checkbox) => data.append("ids[]", checkbox.value))
 
-        Rails.ajax({
-          url: `/madmin/bulk/${this.resourcesValue}`,
-          type: "DELETE",
-          data: data
-        })
+        destroy(`/madmin/bulk/${this.resourcesValue}`, { body: data });
       }
     })
   })()

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -92,7 +92,7 @@
       static get targets() {
         return ["checkbox", "checkboxAll", "actionLink"]
       }
-      static values = { resources: String }
+      static values = { resource: String, indexUrl: String }
 
       initialize () {
         this.refresh = this.refresh.bind(this)
@@ -164,7 +164,11 @@
         let data = new FormData()
         this.checked.forEach((checkbox) => data.append("ids[]", checkbox.value))
 
-        destroy(`/madmin/bulk/${this.resourcesValue}`, { body: data });
+        const response = await destroy(`/madmin/bulk/${this.resourceValue}`, { body: data })
+
+        if (response.ok) {
+          window.location = this.indexUrlValue
+        }
       }
     })
   })()

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -86,5 +86,93 @@
         }
       }
     })
+
+    application.register('bulk-actions', class extends Controller {
+      static get targets() {
+        return ["checkbox", "checkboxAll", "actionLink"]
+      }
+      static values = { resources: String }
+
+      initialize () {
+        this.refresh = this.refresh.bind(this)
+        this.toggle = this.toggle.bind(this)
+        this.disableActionLink();
+      }
+
+      connect() {
+        this.checkboxTargets.forEach(checkbox => checkbox.addEventListener('change', this.refresh))
+        this.checkboxAllTarget.addEventListener('change', this.toggle)
+
+        this.refresh()
+      }
+
+      disconnect() {
+        this.checkboxAllTarget.removeEventListener('change', this.toggle)
+        this.checkboxTargets.forEach(checkbox => checkbox.removeEventListener('change', this.refresh))
+      }
+
+      disableActionLink() {
+        this.actionLinkTarget.disabled = true
+        this.actionLinkTarget.classList.remove("text-indigo-500")
+        this.actionLinkTarget.classList.add("text-gray-400", "cursor-default")
+      }
+
+      enableActionLink() {
+        this.actionLinkTarget.disabled = false
+        this.actionLinkTarget.classList.add("text-indigo-500")
+        this.actionLinkTarget.classList.remove("text-gray-400", "cursor-default")
+      }
+
+      toggle (e) {
+        e.preventDefault()
+
+        this.checkboxTargets.forEach(checkbox => {
+          checkbox.checked = e.target.checked
+          this.triggerInputEvent(checkbox)
+        })
+      }
+
+      triggerInputEvent (checkbox) {
+        const event = new Event('input', { bubbles: false, cancelable: true })
+        checkbox.dispatchEvent(event)
+      }
+
+      refresh() {
+        const checkboxesCount = this.checkboxTargets.length
+        const checkboxesCheckedCount = this.checked.length
+
+        if (checkboxesCheckedCount > 0) {
+          this.checkboxAllTarget.checked = true
+          this.enableActionLink();
+        } else {
+          this.checkboxAllTarget.checked = false
+          this.disableActionLink();
+        }
+        this.checkboxAllTarget.indeterminate = checkboxesCheckedCount > 0 && checkboxesCheckedCount < checkboxesCount
+      }
+
+      get checked () {
+        return this.checkboxTargets.filter(checkbox => checkbox.checked)
+      }
+
+      destroy(event) {
+        event.preventDefault()
+
+        if (!this.checked.length) return;
+
+        let data = new FormData()
+        if (this.checked.length == this.checkboxTargets.length) {
+          data.append("all", true)
+        } else {
+          this.checked.forEach((checkbox) => data.append("ids[]", checkbox.value))
+        }
+
+        Rails.ajax({
+          url: `/madmin/bulk/${this.resourcesValue}`,
+          type: "DELETE",
+          data: data
+        })
+      }
+    })
   })()
 </script>

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -28,32 +28,42 @@
   <% end %>
 </div>
 
-<table class="min-w-full divide-y divide-gray-200">
-  <thead>
-    <tr class="border-b border-gray-200">
-      <% resource.attributes.values.each do |attribute| %>
-        <% next if attribute.field.nil? %>
-        <% next unless attribute.field.visible?(action_name) %>
-
-        <th class="py-2 px-4 text-left text-xs text-gray-500 font-medium uppercase whitespace-nowrap"><%= sortable attribute.name, attribute.name.to_s.titleize %></th>
-      <% end %>
-      <th class="py-2 px-4 text-left text-xs text-gray-500 font-medium uppercase">Actions</th>
-    </tr>
-  </thead>
-
-  <tbody class="text-sm divide-y">
-    <% @records.each do |record| %>
-      <tr>
+<div data-controller="bulk-actions" data-bulk-actions-resources-value="<%= resource.model_name.pluralize.downcase %>">
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead>
+      <th class="py-2 text-left text-xs text-gray-500 font-medium uppercase whitespace-nowrap">
+        <%= check_box_tag nil, nil, false, data: { 'bulk-actions-target': "checkboxAll" } %>
+      </th>
+      <tr class="border-b border-gray-200">
         <% resource.attributes.values.each do |attribute| %>
           <% next if attribute.field.nil? %>
           <% next unless attribute.field.visible?(action_name) %>
-          <td class="px-4 py-2"><%= render partial: attribute.field.to_partial_path("index"), locals: { field: attribute.field, record: record } %></td>
-        <% end %>
 
-        <td class="px-4 py-2 text-center"><%= link_to "View", resource.show_path(record), class: "text-indigo-500" %></td>
+          <th class="py-2 px-4 text-left text-xs text-gray-500 font-medium uppercase whitespace-nowrap"><%= sortable attribute.name, attribute.name.to_s.titleize %></th>
+        <% end %>
+        <th class="py-2 px-4 text-left text-xs text-gray-500 font-medium uppercase">Actions</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody class="text-sm divide-y">
+      <% @records.each do |record| %>
+        <tr>
+          <td>
+            <%= check_box_tag "ids[]", record.id, false, data: { 'bulk-actions-target': "checkbox" } %>
+          </td>
+          <% resource.attributes.values.each do |attribute| %>
+            <% next if attribute.field.nil? %>
+            <% next unless attribute.field.visible?(action_name) %>
+            <td class="px-4 py-2"><%= render partial: attribute.field.to_partial_path("index"), locals: { field: attribute.field, record: record } %></td>
+          <% end %>
+
+          <td class="px-4 py-2 text-center"><%= link_to "View", resource.show_path(record), class: "text-indigo-500" %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <%= link_to "Delete selected", "#", class: "mt-5 inline-block text-indigo-500 text-sm", data: { action: "click->bulk-actions#destroy", "bulk-actions-target": "actionLink" } %>
+</div>
 
 <%== pagy_nav(@pagy) if @pagy.pages > 1 %>

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -28,7 +28,7 @@
   <% end %>
 </div>
 
-<div data-controller="bulk-actions" data-bulk-actions-resources-value="<%= resource.model_name.pluralize.downcase %>">
+<div data-controller="bulk-actions" data-bulk-actions-index-url-value="<%= request.original_url %>" data-bulk-actions-resource-value="<%= resource.model_name.pluralize.downcase %>">
   <table class="min-w-full divide-y divide-gray-200">
     <thead>
       <th class="py-2 text-left text-xs text-gray-500 font-medium uppercase whitespace-nowrap">

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     namespace :active_storage do
       resources :variant_records
     end
+    delete "bulk/:resource", to: "bulk#destroy", as: "bulk_destroy"
     resources :numericals
     resources :habtms
     resources :teams


### PR DESCRIPTION
Work in progress. Comments welcome.

This is the beginnings of bulk delete functionality. This solution uses one `bulk_controller`

```
delete "bulk/:resource", to: "bulk#destroy", as: "bulk_destroy"
```

Reason for that is to simplify the resulting `routes.rb` file in the individual projects. But that also means that we need to pass in the resource you're intending to perform a bulk action on in order to fulfill the URL i.e. `bulk/tasks`. Alternatively we'd have to do something like:

```
namespace :madmin do
  resources :users do
    resource :bulk
  end
end
```

Which can be quite a lot of non-DRY if you have a lot of resources :)

Known issues:

- [x] Fix issue with turbolinks when deleting items (possibly not using Rails.ajax? - currently you get the following error when deleting `ReferenceError: Can't find variable: Turbolinks`)
- [ ] Fix issue when you select all links via the "Select all" checkbox
- [ ] Optional: Styles of "Delete selected" link are currently baked in


There are some smaller issues regarding longer term extendability with this implementation. There's no good way of adding more "Delete selected" type links. Let's say we wanted to add a "Edit all" or "Disable all" link when checkboxes are selected. We could keep this as is for now - with a planned minor refactor when we want to support more use-cases. Or we go ahead and refactor it slightly, so we pass in the "action" url as well as the method (POST/DELETE) via a data-attribute on the link that we can reference form the "destroy" function in the `bulk-actions` controller (of course that needs to be renamed).