### PR TITLE
Add ActiveRecord::Store Support

### DIFF
--- a/db/migrate/20210921230902_change_int_to_bigint.rb
+++ b/db/migrate/20210921230902_change_int_to_bigint.rb
@@ -1,0 +1,11 @@
+class ChangeIntToBigint < ActiveRecord::Migration[6.1]
+  def change
+    change_column :active_storage_attachments, :record_id, :bigint
+    change_column :active_storage_attachments, :blob_id, :bigint
+
+    change_column :active_storage_variant_records, :blob_id, :bigint
+
+    change_column :user_habtms, :user_id, :bigint
+    change_column :user_habtms, :habtm_id, :bigint
+  end
+end

--- a/lib/generators/madmin/resource/resource_generator.rb
+++ b/lib/generators/madmin/resource/resource_generator.rb
@@ -50,6 +50,9 @@ module Madmin
         password_attributes = model.attribute_types.keys.select { |k| k.ends_with?("_digest") }.map { |k| k.delete_suffix("_digest") }
         virtual += password_attributes.map { |attr| [attr, "#{attr}_confirmation"] }.flatten
 
+        # ActiveRecord Store columns
+        virtual += model.stored_attributes.values.flatten
+
         # Add virtual attributes for ActionText and ActiveStorage
         model.reflections.each do |name, association|
           if name.starts_with?("rich_text")
@@ -69,6 +72,9 @@ module Madmin
 
         # has_secure_password columns
         redundant += model.attribute_types.keys.select { |k| k.ends_with?("_digest") }
+
+        # ActiveRecord Store columns
+        redundant += model.stored_attributes.keys
 
         model.reflections.each do |name, association|
           if association.has_one?

--- a/lib/generators/madmin/resource/resource_generator.rb
+++ b/lib/generators/madmin/resource/resource_generator.rb
@@ -125,7 +125,7 @@ module Madmin
           {form: false}
 
         # Attributes without a database column
-        elsif !model.column_names.include?(name) && !(store_accessors.map(&:to_s).include?(name))
+        elsif !model.column_names.include?(name) && !store_accessors.map(&:to_s).include?(name)
           {index: false}
         end
       end

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -192,7 +192,6 @@ module Madmin
         elsif model_store_accessors.include?(name)
           :string
         end
-
       end
 
       def type_for_association(association)

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -187,7 +187,12 @@ module Madmin
         # has_secure_password
         elsif model.attribute_types.include?("#{name_string}_digest") || name_string.ends_with?("_confirmation")
           :password
+
+          # ActiveRecord Store
+        elsif model_store_accessors.include?(name)
+          :string
         end
+
       end
 
       def type_for_association(association)
@@ -204,6 +209,12 @@ module Madmin
 
       def url_helpers
         @url_helpers ||= Rails.application.routes.url_helpers
+      end
+
+      def model_store_accessors
+        store_accessors = model.stored_attributes.values
+
+        store_accessors.flatten
       end
     end
   end

--- a/test/dummy/app/madmin/resources/post_resource.rb
+++ b/test/dummy/app/madmin/resources/post_resource.rb
@@ -1,12 +1,9 @@
 class PostResource < Madmin::Resource
   # Attributes
   attribute :id, form: false
-  attribute :title, field: CustomField
+  attribute :title
   attribute :comments_count, form: false
   attribute :metadata
-  attribute :enum
-  attribute :tags
-  attribute :ratings
   attribute :created_at, form: false
   attribute :updated_at, form: false
   attribute :body, index: false
@@ -14,12 +11,9 @@ class PostResource < Madmin::Resource
   attribute :attachments, index: false
 
   # Associations
-  attribute :versions, form: false
+  attribute :versions
   attribute :user
   attribute :comments
-
-  # Scopes
-  scope :recent
 
   # Uncomment this to customize the display name of records in the admin area.
   # def self.display_name(record)
@@ -27,11 +21,11 @@ class PostResource < Madmin::Resource
   # end
 
   # Uncomment this to customize the default sort column and direction.
-  def self.default_sort_column
-    "title"
-  end
-
-  def self.default_sort_direction
-    "asc"
-  end
+  # def self.default_sort_column
+  #   "created_at"
+  # end
+  #
+  # def self.default_sort_direction
+  #   "desc"
+  # end
 end

--- a/test/dummy/app/madmin/resources/post_resource.rb
+++ b/test/dummy/app/madmin/resources/post_resource.rb
@@ -1,7 +1,7 @@
 class PostResource < Madmin::Resource
   # Attributes
   attribute :id, form: false
-  attribute :title
+  attribute :title, field: CustomField
   attribute :comments_count, form: false
   attribute :metadata
   attribute :created_at, form: false
@@ -11,9 +11,12 @@ class PostResource < Madmin::Resource
   attribute :attachments, index: false
 
   # Associations
-  attribute :versions
+  attribute :versions, form: false
   attribute :user
   attribute :comments
+
+  # Scopes
+  scope :recent
 
   # Uncomment this to customize the display name of records in the admin area.
   # def self.display_name(record)
@@ -21,11 +24,11 @@ class PostResource < Madmin::Resource
   # end
 
   # Uncomment this to customize the default sort column and direction.
-  # def self.default_sort_column
-  #   "created_at"
-  # end
-  #
-  # def self.default_sort_direction
-  #   "desc"
-  # end
+  def self.default_sort_column
+    "title"
+  end
+
+  def self.default_sort_direction
+    "asc"
+  end
 end

--- a/test/dummy/app/madmin/resources/user_resource.rb
+++ b/test/dummy/app/madmin/resources/user_resource.rb
@@ -4,23 +4,29 @@ class UserResource < Madmin::Resource
   attribute :first_name
   attribute :last_name
   attribute :birthday
-  attribute :token, index: false
+  attribute :token
   attribute :created_at, form: false
   attribute :updated_at, form: false
+  attribute :settings
+  attribute :preferences
   attribute :virtual_attribute, index: false
   attribute :password, index: false, show: false
   attribute :password_confirmation, index: false, show: false
+  attribute :language, index: false
+  attribute :notifications, index: false
+  attribute :weekly_email, index: false
+  attribute :monthly_newsletter, index: false
   attribute :avatar, index: false
 
   # Associations
-  attribute :posts, :nested_has_many, skip: %I[enum attachments]
+  attribute :posts
   attribute :comments
   attribute :habtms
 
   # Uncomment this to customize the display name of records in the admin area.
-  def self.display_name(record)
-    "#{record.first_name} #{record.last_name}"
-  end
+  # def self.display_name(record)
+  #   record.name
+  # end
 
   # Uncomment this to customize the default sort column and direction.
   # def self.default_sort_column

--- a/test/dummy/app/madmin/resources/user_resource.rb
+++ b/test/dummy/app/madmin/resources/user_resource.rb
@@ -4,7 +4,7 @@ class UserResource < Madmin::Resource
   attribute :first_name
   attribute :last_name
   attribute :birthday
-  attribute :token
+  attribute :token, index: false
   attribute :created_at, form: false
   attribute :updated_at, form: false
   attribute :virtual_attribute, index: false
@@ -17,14 +17,14 @@ class UserResource < Madmin::Resource
   attribute :avatar, index: false
 
   # Associations
-  attribute :posts
+  attribute :posts, :nested_has_many, skip: %I[attachments]
   attribute :comments
   attribute :habtms
 
   # Uncomment this to customize the display name of records in the admin area.
-  # def self.display_name(record)
-  #   record.name
-  # end
+  def self.display_name(record)
+    "#{record.first_name} #{record.last_name}"
+  end
 
   # Uncomment this to customize the default sort column and direction.
   # def self.default_sort_column

--- a/test/dummy/app/madmin/resources/user_resource.rb
+++ b/test/dummy/app/madmin/resources/user_resource.rb
@@ -7,15 +7,13 @@ class UserResource < Madmin::Resource
   attribute :token
   attribute :created_at, form: false
   attribute :updated_at, form: false
-  attribute :settings
-  attribute :preferences
   attribute :virtual_attribute, index: false
   attribute :password, index: false, show: false
   attribute :password_confirmation, index: false, show: false
-  attribute :language, index: false
-  attribute :notifications, index: false
-  attribute :weekly_email, index: false
-  attribute :monthly_newsletter, index: false
+  attribute :language
+  attribute :notifications
+  attribute :weekly_email
+  attribute :monthly_newsletter
   attribute :avatar, index: false
 
   # Associations

--- a/test/dummy/app/models/post.rb
+++ b/test/dummy/app/models/post.rb
@@ -11,7 +11,5 @@ class Post < ApplicationRecord
 
   scope :recent, -> { where(created_at: 2.weeks.ago..) }
 
-  enum enum: [ :draft, :published, :archived]
-
   validates :title, presence: true
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -11,6 +11,9 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
+  store :preferences, [:language, :notifications]
+  store_accessor :settings, [:weekly_email, :monthly_newsletter]
+
   has_secure_password
   has_secure_token
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
-  store :preferences, [:language, :notifications]
+  store :preferences, accessors: [:language, :notifications], coder: JSON
   store_accessor :settings, [:weekly_email, :monthly_newsletter]
 
   has_secure_password

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,5 +2,10 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "home#index"
 
-  draw(:madmin)
+  if Gem.loaded_specs["rails"].version >= Gem::Version.new(6.1)
+    draw(:madmin)
+  else
+    route_path = "#{Rails.root}/config/routes/madmin.rb"
+    instance_eval(File.read(route_path), route_path.to_s)
+  end
 end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,34 +1,6 @@
 Rails.application.routes.draw do
-  namespace :madmin do
-    namespace :paper_trail do
-      resources :versions
-    end
-    namespace :active_storage do
-      resources :variant_records
-    end
-    resources :numericals
-    resources :habtms
-    resources :teams
-    root to: "dashboard#show"
-    resources :users
-    resources :comments
-    resources :posts
-    namespace :action_text do
-      resources :rich_texts
-    end
-    namespace :user do
-      resources :connected_accounts
-    end
-    namespace :active_storage do
-      resources :blobs
-    end
-    namespace :active_storage do
-      resources :attachments
-    end
-    namespace :action_mailbox do
-      resources :inbound_emails
-    end
-  end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: "home#index"
+
+  draw(:madmin)
 end

--- a/test/dummy/config/routes/madmin.rb
+++ b/test/dummy/config/routes/madmin.rb
@@ -1,0 +1,30 @@
+namespace :madmin do
+  namespace :paper_trail do
+    resources :versions
+  end
+  namespace :active_storage do
+    resources :variant_records
+  end
+  resources :numericals
+  resources :habtms
+  resources :teams
+  root to: "dashboard#show"
+  resources :users
+  resources :comments
+  resources :posts
+  namespace :action_text do
+    resources :rich_texts
+  end
+  namespace :user do
+    resources :connected_accounts
+  end
+  namespace :active_storage do
+    resources :blobs
+  end
+  namespace :active_storage do
+    resources :attachments
+  end
+  namespace :action_mailbox do
+    resources :inbound_emails
+  end
+end

--- a/test/dummy/db/migrate/20210915051634_adds_settings_to_user.rb
+++ b/test/dummy/db/migrate/20210915051634_adds_settings_to_user.rb
@@ -1,0 +1,5 @@
+class AddsSettingsToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :settings, :json
+  end
+end

--- a/test/dummy/db/migrate/20210915141444_add_preferences_to_users.rb
+++ b/test/dummy/db/migrate/20210915141444_add_preferences_to_users.rb
@@ -1,0 +1,5 @@
+class AddPreferencesToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :preferences, :text
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 2021_09_21_230902) do
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
-    t.integer "status", default: 0, null: false
+    t.bigint "status", default: 0, null: false
     t.string "message_id", null: false
     t.string "message_checksum", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2021_09_21_230902) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
+    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
@@ -60,9 +60,9 @@ ActiveRecord::Schema.define(version: 2021_09_21_230902) do
   end
 
   create_table "comments", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.string "commentable_type", null: false
-    t.integer "commentable_id", null: false
+    t.bigint "commentable_id", null: false
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2021_09_21_230902) do
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id"
     t.string "title"
-    t.integer "comments_count"
+    t.bigint "comments_count"
     t.json "metadata"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2021_09_21_230902) do
   end
 
   create_table "user_connected_accounts", force: :cascade do |t|
-    t.integer "user_id", null: false
+    t.bigint "user_id", null: false
     t.string "service"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -100,7 +100,7 @@ ActiveRecord::Schema.define(version: 2021_09_21_230902) do
   end
 
   create_table "user_habtms", force: :cascade do |t|
-    t.integer "user_id"
+    t.bigint "user_id"
     t.bigint "habtm_id"
     t.index ["habtm_id"], name: "index_user_habtms_on_habtm_id"
     t.index ["user_id"], name: "index_user_habtms_on_user_id"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_14_192556) do
+ActiveRecord::Schema.define(version: 2021_09_15_141444) do
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
@@ -34,8 +34,8 @@ ActiveRecord::Schema.define(version: 2021_06_14_192556) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2021_06_14_192556) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -86,9 +86,6 @@ ActiveRecord::Schema.define(version: 2021_06_14_192556) do
     t.string "title"
     t.integer "comments_count"
     t.json "metadata"
-    t.integer "enum"
-    t.string "tags"
-    t.integer "ratings"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
@@ -103,8 +100,8 @@ ActiveRecord::Schema.define(version: 2021_06_14_192556) do
   end
 
   create_table "user_habtms", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "habtm_id"
+    t.integer "user_id"
+    t.integer "habtm_id"
     t.index ["habtm_id"], name: "index_user_habtms_on_habtm_id"
     t.index ["user_id"], name: "index_user_habtms_on_user_id"
   end
@@ -117,6 +114,8 @@ ActiveRecord::Schema.define(version: 2021_06_14_192556) do
     t.string "token"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.json "settings"
+    t.text "preferences"
   end
 
   create_table "versions", force: :cascade do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_15_141444) do
+ActiveRecord::Schema.define(version: 2021_09_21_230902) do
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2021_09_15_141444) do
     t.string "name", null: false
     t.string "record_type", null: false
     t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -54,15 +54,15 @@ ActiveRecord::Schema.define(version: 2021_09_15_141444) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
   create_table "comments", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.integer "user_id", null: false
     t.string "commentable_type", null: false
-    t.bigint "commentable_id", null: false
+    t.integer "commentable_id", null: false
     t.text "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 2021_09_15_141444) do
   end
 
   create_table "user_connected_accounts", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.integer "user_id", null: false
     t.string "service"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -101,7 +101,7 @@ ActiveRecord::Schema.define(version: 2021_09_15_141444) do
 
   create_table "user_habtms", force: :cascade do |t|
     t.integer "user_id"
-    t.integer "habtm_id"
+    t.bigint "habtm_id"
     t.index ["habtm_id"], name: "index_user_habtms_on_habtm_id"
     t.index ["user_id"], name: "index_user_habtms_on_user_id"
   end

--- a/test/madmin/nested_form_test.rb
+++ b/test/madmin/nested_form_test.rb
@@ -21,7 +21,7 @@ class NestedHasManyTest < ActiveSupport::TestCase
 
   test "whitelists unskipped and required params" do
     field = UserResource.attributes[:posts].field
-    expected_params = [:title, :metadata, :tags, :ratings, :body, :image, "user_id", "_destroy", "id"]
+    expected_params = [:title, :metadata, :body, :image, "user_id", "_destroy", "id"]
     assert expected_params.all? { |p| field.to_param[:posts_attributes].include?(p) }
   end
 end


### PR DESCRIPTION
This is a start of a PR to address #95. I'm not totally familiar with how Madmin works internally, so I think I just need to address this at the generator level. My understanding is after the Madmin class is generated, the super classing just shoves the generated attributes into the `attributes` class attribute using the attributes API. At least that's as far as I understood.

Regardless, this still needs tests, so let me know if there's something I missed. I poked around a bit, but I was a bit time-pressured tonight.