### PR TITLE
Refactor filter_map to two calls for compatibility

### DIFF
--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -89,7 +89,7 @@ module Madmin
       end
 
       def permitted_params
-        attributes.values.find_all { |a| a.field.visible?(:form) }.map { |a| a.field.to_param }
+        attributes.values.filter { |a| a.field.visible?(:form) }.map { |a| a.field.to_param }
       end
 
       def display_name(record)

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -89,7 +89,7 @@ module Madmin
       end
 
       def permitted_params
-        attributes.values.filter_map { |a| a.field.to_param if a.field.visible?(:form) }
+        attributes.values.find_all { |a| a.field.visible?(:form) }.map { |a| a.field.to_param }
       end
 
       def display_name(record)


### PR DESCRIPTION
2.7 was the revision that introduced filter_map and the gemspec calls for 2.5.0 as a minimum ruby version

should close https://github.com/excid3/jumpstart/issues/144

