### PR TITLE
fix: Prevents namespace collision with helpers

### DIFF
--- a/lib/madmin/engine.rb
+++ b/lib/madmin/engine.rb
@@ -8,5 +8,15 @@ module Madmin
     config.to_prepare do
       Madmin.reset_resources!
     end
+
+    # Isolating the helpers from the main app
+    config.after_initialize do |app|
+      railtie = self
+      Madmin.singleton_class.instance_eval do
+        define_method(:railtie_helpers_paths) { railtie.helpers_paths }
+      end
+
+      app.config.helpers_paths.delete(*paths["app/helpers"].existent)
+    end
   end
 end

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def sortable
+    "I don't collide"
+  end
 end

--- a/test/dummy/app/views/home/index.html.erb
+++ b/test/dummy/app/views/home/index.html.erb
@@ -1,2 +1,5 @@
 <h1>There's nothing here, this is a test app for Madmin</h1>
 <%= link_to "View Madmin", "/madmin", class: "btn btn-primary" %>
+
+<h2>Testing for namespace collision</h2>
+<%= content_tag :span, sortable %>


### PR DESCRIPTION
Resolves #114

This is a pretty hacky solution, and could probably use some tests to prevent regression. I'm not entirely sure where we'd test that though. For now I've added a helper to `HomeController` to test things out manually.

I've essentially just ripped some of the code out of `isolate_namespace`. I'm concerned there might be some side effects, so it's definitely worth a solid look before merging.