### PR TITLE
Adds spaces to friendly_name for multi-word Models

### DIFF
--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -55,7 +55,7 @@ module Madmin
       end
 
       def friendly_name
-        model_name.gsub("::", " / ")
+        model_name.gsub("::", " / ").split(/(?=[A-Z])/).join(" ")
       end
 
       # Support for isolated namespaces

--- a/test/madmin/resource_test.rb
+++ b/test/madmin/resource_test.rb
@@ -1,5 +1,7 @@
 require "test_helper"
 
+class FooBarBazResource < Madmin::Resource; end
+
 class ResourceTest < ActiveSupport::TestCase
   test "searchable_attributes" do
     searchable_attribute_names = UserResource.searchable_attributes.map { |a| a[:name] }
@@ -8,5 +10,10 @@ class ResourceTest < ActiveSupport::TestCase
 
   test "rich_text" do
     assert_equal :rich_text, PostResource.attributes[:body].type
+  end
+
+  test "friendly_name" do
+    assert_equal "User", UserResource.friendly_name
+    assert_equal "Foo Bar Baz", FooBarBazResource.friendly_name
   end
 end


### PR DESCRIPTION
With current behavior, multi-word models names appear with no spaces: `FooBar`

With update, will appear as `Foo Bar`