### PR TITLE
fix: Add search param to the request in select input

### DIFF
--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -38,7 +38,8 @@
           labelField: 'name',
           searchField: 'name',
           load: (search, callback) => {
-            fetch(this.urlValue)
+            let url = search ? `${this.urlValue}?q=${search}` : this.urlValue;
+            fetch(url)
               .then(response => response.json())
               .then(json => {
                 callback(json);


### PR DESCRIPTION
## Why??
`search` param is not passed in the request. The fetched records (options for select) are not filtered out by the search term.

## What??
Add `q` param to the request.
