### PR TITLE
fix: Add support for :timestamptz (timestamp with time zone) field

### DIFF
--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -129,6 +129,7 @@ module Madmin
           text: Fields::Text,
           time: Fields::Time,
           timestamp: Fields::Time,
+          timestamptz: Fields::Time,
           password: Fields::Password,
           file: Fields::File,
 


### PR DESCRIPTION
## Why

Madmin does not currently support timestamps with time zone fields". **Note**: I encountered this issue while trying to upgrade our app to Rails 7.