### PR TITLE
Pin unpkg tailwind plugin versions

### DIFF
--- a/app/views/layouts/madmin/application.html.erb
+++ b/app/views/layouts/madmin/application.html.erb
@@ -7,9 +7,9 @@
     <title>
       Madmin: <%= Rails.application.class %>
     </title>
-    <link href="https://unpkg.com/@tailwindcss/forms/dist/forms.min.css" rel="stylesheet" />
+    <link href="https://unpkg.com/@tailwindcss/forms@0.3.4/dist/forms.min.css" rel="stylesheet" />
     <link href="https://unpkg.com/tailwindcss@^2.0/dist/tailwind.min.css" rel="stylesheet" />
-    <link href="https://unpkg.com/@tailwindcss/typography/dist/typography.min.css" rel="stylesheet" />
+    <link href="https://unpkg.com/@tailwindcss/typography@0.5.0/dist/typography.min.css" rel="stylesheet" />
     <%= csrf_meta_tags %>
 
     <%= render "javascript" %>


### PR DESCRIPTION
The latest releases of these tailwind plugins have either renamed the dist
css file, stopped serving it altogether, or reference Tailwind v3.

In this commit I pin typography and forms to the latest versions that
worked with Tailwind 2 in its current form.

Fixes #141