### PR TITLE
Update layout to use Tailwind play CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ rails generate madmin:views:index Book
  # -> app/views/madmin/books/index.html.erb
 ```
 
+## Styling
+
+Madmin uses the Tailwind CSS "Play CDN" by default. The Tailwind team [does not recommend its usage for production](https://tailwindcss.com/docs/installation/play-cdn). The CDN will use the latest available version of Tailwind, which might cause problems if you've customized Madmin's views.
+
+Consider overriding the default madmin layout in `Madmin::ApplicationController` if you need more control.
+
 ## Custom Fields
 
 You can generate a custom field with:

--- a/app/views/layouts/madmin/application.html.erb
+++ b/app/views/layouts/madmin/application.html.erb
@@ -7,9 +7,6 @@
     <title>
       Madmin: <%= Rails.application.class %>
     </title>
-    <link href="https://unpkg.com/@tailwindcss/forms/dist/forms.min.css" rel="stylesheet" />
-    <link href="https://unpkg.com/tailwindcss@^2.0/dist/tailwind.min.css" rel="stylesheet" />
-    <link href="https://unpkg.com/@tailwindcss/typography/dist/typography.min.css" rel="stylesheet" />
     <%= csrf_meta_tags %>
 
     <%= render "javascript" %>

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -1,3 +1,5 @@
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+
 <%= stylesheet_link_tag "https://unpkg.com/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/trix/dist/trix.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/tom-select/dist/css/tom-select.min.css", "data-turbo-track": "reload" %>


### PR DESCRIPTION
Follow up from #143 

Per @excid3 suggestion, this commit removes pinned references to Tailwind packages in favor of their Play CDN, with additions to the README explaining its implications.

Fixes #141