### PR TITLE
Add SimpleCov support to the test suite 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "byebug", group: [:development, :test]
 gem "standardrb", group: [:development, :test]
 gem "ffaker", "~> 2.17"
 gem "name_of_person", "~> 1.1", ">= 1.1.1"
+gem "simplecov", group: :test
 gem "web-console", group: :development
 gem "webpacker", "~> 5.2", ">= 5.2.1"
 gem "friendly_id", "~> 5.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    docile (1.4.0)
     erubi (1.10.0)
     ffaker (2.20.0)
     friendly_id (5.4.2)
@@ -171,6 +172,12 @@ GEM
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
     semantic_range (3.0.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sqlite3 (1.4.2)
     standard (1.5.0)
       rubocop (= 1.23.0)
@@ -214,6 +221,7 @@ DEPENDENCIES
   paper_trail (~> 12.0)
   pg
   puma
+  simplecov
   sqlite3
   standardrb
   web-console

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,13 @@
+# Configure SimpleCov
+if ENV["COVERAGE"] == "true"
+  puts "Calculating Code Coverage with SimpleCov"
+
+  require "simplecov"
+  SimpleCov.start "rails"
+
+  puts "Required SimpleCov"
+end
+
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 


### PR DESCRIPTION
Hi there! 

This commit will add the `simplecov` dependency to the test group and require if someone wants to run the test suite with COVERAGE=true.

It might help us figure out what files could benefit from having more scenarios. 

Here are a couple of screenshots of the reports that could be generated: 

![Screen Shot 2022-09-26 at 4 32 43 PM](https://user-images.githubusercontent.com/17584/192379223-5f6aad5c-de88-4b86-84b1-b4a23a8217af.png)

![Screen Shot 2022-09-26 at 4 32 55 PM](https://user-images.githubusercontent.com/17584/192379225-ec890a0e-2506-47df-96b3-458e69d19024.png)

Please check it out and let me know what you think. 

Thanks! 