### PR TITLE
Allow pagy to update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     madmin (1.2.7)
-      pagy (>= 3.5, < 6.0)
+      mail (>= 2.8.0)
+      pagy (>= 3.5, < 7.0)
       rails (>= 6.0.3)
 
 GEM
@@ -78,6 +79,7 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    date (3.3.3)
     docile (1.4.0)
     erubi (1.11.0)
     ffaker (2.21.0)
@@ -91,8 +93,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -101,13 +106,18 @@ GEM
     mysql2 (0.5.4)
     name_of_person (1.1.1)
       activesupport (>= 5.2.0)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     pagy (5.10.1)
       activesupport
@@ -188,6 +198,7 @@ GEM
       standard
     stringio (3.0.4)
     thor (1.2.1)
+    timeout (0.3.2)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.5.0)

--- a/madmin.gemspec
+++ b/madmin.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5.0"
 
   spec.add_dependency "rails", ">= 6.0.3"
-  spec.add_dependency "pagy", ">= 3.5", "< 6.0"
+  spec.add_dependency "pagy", ">= 3.5", "< 7.0"
+  spec.add_dependency "mail", ">= 2.8.0"
 end


### PR DESCRIPTION
It was a standard update although there were [net-smtp issues](https://github.com/rails/rails/pull/44083). I think just relying on mail 2.8.0 is the most graceful solution.