### PR TITLE
Fix new url tailwindcss-stimulus-components

### DIFF
--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -13,7 +13,7 @@
       "@rails/activestorage": "https://unpkg.com/@rails/activestorage@<%= npm_rails_version %>/app/assets/javascripts/activestorage.esm.js",
       "flatpickr": "https://unpkg.com/flatpickr/dist/esm/index.js",
       "stimulus-flatpickr": "https://unpkg.com/stimulus-flatpickr@3.0.0-0/dist/index.m.js",
-      "tailwindcss-stimulus-components": "https://unpkg.com/tailwindcss-stimulus-components/dist/tailwindcss-stimulus-components.modern.js",
+      "tailwindcss-stimulus-components": "https://unpkg.com/tailwindcss-stimulus-components/dist/tailwindcss-stimulus-components.module.js",
       "tom-select": "https://unpkg.com/tom-select/dist/esm/tom-select.complete.js",
       "trix": "https://unpkg.com/trix"
     }


### PR DESCRIPTION
Change url to make it works with last `tailwindcss-stimulus-components` release

resolves #173