### PR TITLE
Fix & warning interpreted as argument prefix

### DIFF
--- a/app/views/madmin/application/show.html.erb
+++ b/app/views/madmin/application/show.html.erb
@@ -7,7 +7,7 @@
 
   <div class="flex gap-2 items-center px-4">
     <% resource.member_actions.each do |action| %>
-      <%= instance_eval &action  %>
+      <%= instance_eval(&action)  %>
     <% end %>
     <%= link_to "Edit", resource.edit_path(@record), class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow" %>
     <%= button_to "Delete", resource.show_path(@record), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "bg-white hover:bg-gray-100 text-red-500 font-semibold py-2 px-4 border border-red-500 rounded shadow pointer-cursor" %>


### PR DESCRIPTION
This is the warning I saw when running the test suite.

```bash
madmin/app/views/madmin/application/show.html.erb:10: warning: `&' interpreted as argument prefix
```
