### PR TITLE
Add flex-grow to all form inputs

### DIFF
--- a/app/views/madmin/fields/decimal/_form.html.erb
+++ b/app/views/madmin/fields/decimal/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.number_field field.attribute_name, step: :any, class: "form-input" %>
+<%= form.number_field field.attribute_name, step: :any, class: "flex-grow form-input" %>

--- a/app/views/madmin/fields/file/_form.html.erb
+++ b/app/views/madmin/fields/file/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.file_field field.attribute_name, class: "form-input" %>
+<%= form.file_field field.attribute_name, class: "flex-grow form-input" %>

--- a/app/views/madmin/fields/float/_form.html.erb
+++ b/app/views/madmin/fields/float/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.number_field field.attribute_name, step: :any, class: "form-input" %>
+<%= form.number_field field.attribute_name, step: :any, class: "flex-grow form-input" %>

--- a/app/views/madmin/fields/integer/_form.html.erb
+++ b/app/views/madmin/fields/integer/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.number_field field.attribute_name, class: "form-input" %>
+<%= form.number_field field.attribute_name, class: "flex-grow form-input" %>

--- a/app/views/madmin/fields/json/_form.html.erb
+++ b/app/views/madmin/fields/json/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.text_area field.attribute_name, class: "form-input" %>
+<%= form.text_area field.attribute_name, class: "flex-grow form-input" %>

--- a/app/views/madmin/fields/password/_form.html.erb
+++ b/app/views/madmin/fields/password/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.password_field field.attribute_name, class: "form-input" %>
+<%= form.password_field field.attribute_name, class: "flex-grow form-input" %>

--- a/app/views/madmin/fields/rich_text/_form.html.erb
+++ b/app/views/madmin/fields/rich_text/_form.html.erb
@@ -2,5 +2,5 @@
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
 <div class="flex-1">
-  <%= form.rich_text_area field.attribute_name, class: "form-input block" %>
+  <%= form.rich_text_area field.attribute_name, class: "flex-grow form-input block" %>
 </div>

--- a/app/views/madmin/fields/string/_form.html.erb
+++ b/app/views/madmin/fields/string/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.text_field field.attribute_name, class: "form-input" %>
+<%= form.text_field field.attribute_name, class: "flex-grow form-input" %>

--- a/app/views/madmin/fields/text/_form.html.erb
+++ b/app/views/madmin/fields/text/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.text_area field.attribute_name, class: "form-input" %>
+<%= form.text_area field.attribute_name, class: "flex-grow form-input" %>

--- a/lib/generators/madmin/field/templates/_form.html.erb
+++ b/lib/generators/madmin/field/templates/_form.html.erb
@@ -1,4 +1,4 @@
 <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
-<%= form.text_field field.attribute_name, class: "form-input" %>
+<%= form.text_field field.attribute_name, class: "flex-grow form-input" %>

--- a/test/dummy/app/views/madmin/fields/custom_field/_form.html.erb
+++ b/test/dummy/app/views/madmin/fields/custom_field/_form.html.erb
@@ -1,2 +1,2 @@
 <%= form.label field.attribute_name, class: "inline-block w-32 flex-shrink-0" %>
-<%= form.text_field field.attribute_name, class: "form-input" %>
+<%= form.text_field field.attribute_name, class: "flex-grow form-input" %>


### PR DESCRIPTION
This enhances the UI of the form pages to allow the inputs to fill up the space and grow. This helps resolve the original complaint in #181 and makes the forms usable by default without needing to customize the views. 

![image](https://github.com/excid3/madmin/assets/1741179/6f6dac3e-1d02-4e73-a781-7c3ab9cbed1a)
