### PR TITLE
Remove line-clamp plugin which is now built in to Tailwind

### DIFF
--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -1,4 +1,4 @@
-<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 <%= stylesheet_link_tag "https://unpkg.com/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/trix/dist/trix.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/tom-select/dist/css/tom-select.min.css", "data-turbo-track": "reload" %>


### PR DESCRIPTION
Just following the console's recommendation to remove line-clamp as it's now built in Tailwind v3.3

![CleanShot 2024-06-12 at 12 38 54@2x](https://github.com/excid3/madmin/assets/1741179/6ee89f80-e0ef-4d19-8d05-8b121f93482f)
