### PR TITLE
Remove TailwindCSS CDN and ship as tailwindcss-rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/dummy/tmp/
 test/dummy/node_modules/
 .DS_Store
 .idea/
+app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "puma"
 gem "sprockets-rails"
 gem "standardrb"
 gem "web-console", group: :development
+gem "tailwindcss-rails"
 
 # Databases to test against
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,14 @@ GEM
       standard
     stringio (3.1.1)
     strscan (3.1.0)
+    tailwindcss-rails (2.7.3)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.3-arm64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.3-x86_64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.3-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -294,6 +302,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (~> 1.4)
   standardrb
+  tailwindcss-rails
   web-console
 
 BUNDLED WITH

--- a/app/assets/config/madmin_manifest.js
+++ b/app/assets/config/madmin_manifest.js
@@ -1,1 +1,2 @@
 //= link_directory ../stylesheets/madmin .css
+//= link_tree ../builds

--- a/app/assets/stylesheets/madmin/application.css
+++ b/app/assets/stylesheets/madmin/application.css
@@ -12,4 +12,6 @@
  *
  *= require_tree .
  *= require_self
+ *= stub ./application.tailwind.css
+ *
  */

--- a/app/assets/stylesheets/madmin/application.tailwind.css
+++ b/app/assets/stylesheets/madmin/application.tailwind.css
@@ -1,0 +1,33 @@
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
+
+.pagy {
+  @apply isolate inline-flex rounded-md;
+
+  a:first-child {
+    @apply rounded-l-md;
+  }
+  a:last-child {
+    @apply rounded-r-md;
+  }
+
+  a {
+    @apply relative -ml-px inline-flex items-center bg-white px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-100 focus:z-10;
+
+    &:not([href]) {
+      @apply text-gray-300 cursor-default;
+    }
+
+    &.current {
+      @apply text-white bg-blue-500 ring-blue-500;
+    }
+  }
+
+  label {
+    @apply inline-block whitespace-nowrap bg-gray-200 rounded-lg px-3 py-0.5;
+    input {
+      @apply bg-gray-100 border-none rounded-md;
+    }
+  }
+}

--- a/app/views/layouts/madmin/application.html.erb
+++ b/app/views/layouts/madmin/application.html.erb
@@ -11,6 +11,7 @@
     <%= csrf_meta_tags %>
 
     <%= render "javascript" %>
+    <%= stylesheet_link_tag "madmin", "inter-font", "data-turbo-track": "reload" %>
   </head>
   <body class="min-h-screen">
     <div class="md:flex w-full min-h-screen">

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -1,39 +1,7 @@
-<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
 <%= stylesheet_link_tag "madmin/application", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/trix/dist/trix.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/tom-select/dist/css/tom-select.min.css", "data-turbo-track": "reload" %>
-<style type="text/tailwindcss">
-.pagy {
-  @apply isolate inline-flex rounded-md;
-
-  a:first-child {
-    @apply rounded-l-md;
-  }
-  a:last-child {
-    @apply rounded-r-md;
-  }
-
-  a {
-    @apply relative -ml-px inline-flex items-center bg-white px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-100 focus:z-10;
-
-    &:not([href]) {
-      @apply text-gray-300 cursor-default;
-    }
-
-    &.current {
-      @apply text-white bg-blue-500 ring-blue-500;
-    }
-  }
-
-  label {
-    @apply inline-block whitespace-nowrap bg-gray-200 rounded-lg px-3 py-0.5;
-    input {
-      @apply bg-gray-100 border-none rounded-md;
-    }
-  }
-}
-</style>
 
 <script type="importmap" data-turbo-track="reload">
   {

--- a/config/madmin/postcss.config.js
+++ b/config/madmin/postcss.config.js
@@ -1,0 +1,7 @@
+// config/postcss.config.js
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/config/madmin/tailwind.config.js
+++ b/config/madmin/tailwind.config.js
@@ -1,0 +1,30 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+const path = require('path')
+
+// Determine the engine root path
+const engineRoot = path.resolve(__dirname, '../..')
+
+module.exports = {
+  content: [
+    path.join(engineRoot, 'app/views/**/*.{erb,haml,html,slim}'),
+    path.join(engineRoot, 'app/helpers/**/*.rb'),
+    path.join(engineRoot, 'app/javascript/**/*.js'),
+    // Include potential overrides from the main app
+    path.join(process.cwd(), 'app/views/madmin/**/*.{erb,haml,html,slim}'),
+    path.join(process.cwd(), 'app/helpers/madmin/**/*.rb'),
+    path.join(process.cwd(), 'app/javascript/madmin/**/*.js'),
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+    require('@tailwindcss/aspect-ratio')
+  ]
+}

--- a/lib/madmin/engine.rb
+++ b/lib/madmin/engine.rb
@@ -12,7 +12,27 @@ module Madmin
     end
 
     initializer "madmin.assets" do |app|
-      app.config.assets.precompile += %w[madmin_manifest]
+      app.config.assets.precompile += %w[madmin_manifest madmin.css]
+    end
+
+    initializer "madmin.compile_tailwind_css" do |app|
+      # Skip if not running in a Rails server
+      next unless defined?(::Rails::Server)
+
+      input_file = Engine.root.join("app/assets/stylesheets/madmin/application.tailwind.css")
+      output_file = Engine.root.join("app/assets/builds/madmin.css")
+      config_file = Engine.root.join("config/madmin/tailwind.config.js")
+      postcss_file = Engine.root.join("config/madmin/postcss.config.js")
+
+      if Rails.env.development?
+        Thread.new do
+          system("bundle exec tailwindcss -i #{input_file} -o #{output_file} --config #{config_file} --postcss #{postcss_file} --watch")
+        end
+      end
+
+      if Rails.env.production?
+        system("bundle exec tailwindcss -i #{input_file} -o #{output_file} --config #{config_file} --postcss #{postcss_file} --minify")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR addresses the request to remove the TailwindCSS CDN and include our own stylesheet, as @excid3 said in [issue #198](https://github.com/excid3/madmin/issues/198#issuecomment-2035908582)

> I'd like to drop the TailwindCSS CDN and just ship our own stylesheet soon if anyone wants to PR that.
> We could also probably do the same for the JavaScript.
> 
> CDNs were just the easiest to figure out while Rails was in the jsbundling /cssbundling / propshaft / importmap mess. I think things have settled out enough that we can ship our own assets and importmaps. I need to look into how MissionControl handles assets and we can cut a new release with those changes.

## Changes
- Removed CDN link
- Added `tailwindcss-rails` gem (installs standalone exe tailwind)
- Configured Tailwind with PostCSS (changes in host rails, overrided files, reflects in Tailwind)
- Tailwind compilation:
  - Dev: Compiles with `--watch` when Rails server runs
  - Prod: Compiles with `--minify`

Note: Sprockets remains, but Tailwind file is ignored

## Questions

I'm not certain if this PR fully meets your expectations.

1. Should we proceed with similar changes for JavaScript assets?
2. Are we aiming for importmaps with external links, bundled assets, or a mix?
3. Is the referenced MissionControl the `mission_control-jobs` gem? If so, should we follow their approach of using Gemfiles for Stimulus, Turbo, and other packages? like their [importmap](https://github.com/rails/mission_control-jobs/blob/main/config/importmap.rb) and [gemspec](https://github.com/rails/mission_control-jobs/blob/main/mission_control-jobs.gemspec)

I can continue with JavaScript assets once we clarify the preferred approach. Please let me know if any adjustments are needed for this PR or if you'd like me to proceed with further changes.
