### PR TITLE
CSS Restructure: Implementing Pure CSS Stylesheets

### DIFF
--- a/app/assets/stylesheets/madmin/application.css
+++ b/app/assets/stylesheets/madmin/application.css
@@ -10,6 +10,23 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require_tree .
- *= require_self
+ *
  */
+
+ @import 'normalize.css';
+ @import 'variables.css';
+ @import 'typography.css';
+ @import 'layout.css';
+ @import 'navigation.css';
+ @import 'forms.css';
+ @import 'tables.css';
+ @import 'utilities.css';
+ @import 'pagy.css';
+ @import 'pages.css';
+
+ /* TODO: dark mode is ready, uncomment custom.css and check */
+ /*       but there is no toggle-theme feature yet */
+
+ /* @import 'custom.css'; */
+
+ /* TODO: transitions classes */

--- a/app/assets/stylesheets/madmin/custom.css
+++ b/app/assets/stylesheets/madmin/custom.css
@@ -1,0 +1,24 @@
+[data-theme=light],
+:root:not([data-theme=dark]) {
+  /* add light custom here */
+}
+
+@media only screen and (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --color-primary: #818CF8;
+    --bg-color: #0F172A;
+    --bg-color-dark: #5b6679;
+    --bg-color-darker: #8c96a8;
+    --foreground-color: #f7fafc;
+    color-scheme: dark;
+  }
+}
+
+[data-theme=dark] {
+  --color-primary: #818CF8;
+  --bg-color: #0F172A;
+  --bg-color-dark: #5b6679;
+  --bg-color-darker: #8c96a8;
+  --foreground-color: #f7fafc;
+  color-scheme: dark;
+}

--- a/app/assets/stylesheets/madmin/forms.css
+++ b/app/assets/stylesheets/madmin/forms.css
@@ -1,0 +1,160 @@
+.form-input, .form-select{
+  padding      : var(--spacing-2);
+  border       : 1px solid var(--bg-color-dark);
+  border-radius: var(--border-radius);
+  font-size    : 1rem;
+  background-color: var(--bg-color);
+  color: var(--foreground-color);
+}
+
+.form-input:focus, .form-select:focus {
+  outline     : none;
+  border-color: var(--color-primary);
+  box-shadow  : 0 0 0 3px rgba(66, 153, 225, 0.5);
+}
+
+.form__required {
+  color: var(--color-danger);
+}
+
+.form-group {
+  margin-bottom: var(--spacing-4);
+}
+
+.form-group__label-container {
+  margin-bottom: var(--spacing-2);
+  flex-shrink  : 0;
+}
+
+.form-group__field-container {
+  flex-grow: 1;
+}
+
+.form-group__field-container img {
+  margin-top: var(--spacing-2);
+  max-height: 8rem;
+}
+
+.form-group__field-container a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.form-group__field-description {
+  margin-top: var(--spacing-1);
+  color     : var(--bg-color-darker);
+  font-size : 0.875rem;
+}
+
+.form-group__nested-form {
+  margin-top: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group__nested-form > * + * {
+  margin-top: 2rem;
+}
+
+.nested-fields {
+  border: 1px solid var(--bg-color-dark);
+  border-radius: var(--border-radius-xl);
+  padding: var(--spacing-4);
+}
+
+.nested-fields__field {
+  margin-bottom: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+}
+
+.form__submit {
+  margin-top      : var(--spacing-4);
+  padding         : var(--spacing-2) var(--spacing-4);
+  border          : 1px solid var(--bg-color-dark);
+  border-radius   : var(--border-radius);
+  background-color: var(--bg-color);
+  color           : var(--bg-color-darker);
+  font-weight     : 600;
+  cursor          : pointer;
+}
+
+.form__submit:hover {
+  background-color: var(--bg-color-dark);
+}
+
+.form-error {
+  margin-bottom   : var(--spacing-4);
+  padding         : var(--spacing-4);
+  border-radius   : var(--border-radius);
+  background-color: var(--color-danger);
+  color           : white;
+}
+
+.form-error__summary {
+  margin-bottom: var(--spacing-2);
+  font-weight  : 600;
+}
+
+.form-error__list {
+  padding-left   : var(--spacing-4);
+  list-style-type: none;
+}
+
+.form-error__item {
+  margin-bottom: var(--spacing-1);
+}
+
+@media (min-width: 768px) {
+  .form-group {
+    display: flex;
+  }
+
+  .form-group__label-container {
+    display: block;
+    width  : 8rem;
+  }
+}
+
+/* tom select */
+
+.form-select.ts-wrapper {
+  padding: 0 !important;
+}
+
+.ts-control {
+  background-color: var(--bg-color) !important;
+  border: 1px solid var(--bg-color-dark) !important;
+  border-radius: var(--border-radius) !important;
+  font-size: 1rem !important;
+  color: var(--foreground-color) !important;
+}
+
+.ts-control input {
+  color: var(--foreground-color) !important;
+}
+
+.ts-control .item {
+  background-color: var(--bg-color) !important;
+  color: var(--foreground-color) !important;
+  border: 1px solid var(--bg-color-dark) !important;
+}
+
+.ts-dropdown-content {
+  background-color: var(--bg-color) !important;
+  border: 1px solid var(--bg-color-dark) !important;
+  border-radius: var(--border-radius) !important;
+  font-size: 1rem !important;
+  color: var(--foreground-color) !important;
+}
+
+.ts-dropdown .active {
+  background-color: var(--bg-color-dark) !important;
+  color: var(--foreground-color) !important;
+}
+
+/* trix editor */
+
+trix-toolbar .trix-button {
+  background-color: whitesmoke !important;
+}

--- a/app/assets/stylesheets/madmin/layout.css
+++ b/app/assets/stylesheets/madmin/layout.css
@@ -1,0 +1,40 @@
+body {
+  background-color: var(--bg-color);
+  min-height      : 100vh;
+  color           : var(--foreground-color);
+  font-family     : var(--font-sans);
+  font-size       : 1rem;
+  line-height     : 1.5;
+}
+
+#container {
+  width: 100%;
+}
+
+#sidebar {
+  padding         : var(--spacing-4);
+  border-right    : 1px solid var(--bg-color-dark);
+  background-color: var(--bg-color);
+  width           : 100%;
+  height          : auto;
+  overflow        : auto;
+  overflow-y      : auto;
+  flex-shrink     : 0;
+}
+
+main {
+  padding   : var(--spacing-4);
+  overflow-x: scroll;
+  flex-grow : 1;
+}
+
+@media (min-width: 768px) {
+  #container {
+    display   : flex;
+    min-height: 100vh;
+  }
+
+  #sidebar {
+    width: var(--sidebar-width);
+  }
+}

--- a/app/assets/stylesheets/madmin/navigation.css
+++ b/app/assets/stylesheets/madmin/navigation.css
@@ -1,0 +1,118 @@
+.nav {
+  padding  : var(--spacing-1);
+  font-size: 0.875rem;
+}
+
+.nav__header {
+  display        : flex;
+  justify-content: space-between;
+  align-items    : center;
+  margin-bottom  : var(--spacing-4);
+  padding        : var(--spacing-1);
+}
+
+.nav__header h1 {
+  margin-bottom: 0;
+  font-size    : 1.25rem;
+}
+
+.nav__link {
+  display        : block;
+  padding        : var(--spacing-1) var(--spacing-2);
+  border-radius  : var(--border-radius-lg);
+  color          : var(--foreground-color);
+  text-decoration: none;
+  transition     : background-color 0.2s ease;
+}
+
+.nav__link:hover {
+  background-color: var(--color-primary);
+}
+
+.nav__link--active,
+.nav__link--active:hover {
+  background-color: var(--color-primary);
+  color           : var(--foreground-color);
+  font-weight     : 600;
+}
+
+#main-menu.nav__link {
+  border          : 0;
+  background-color: transparent;
+}
+
+#main-menu .icon {
+  width : var(--spacing-5);
+  height: var(--spacing-5);
+}
+
+.nav__back-link {
+  padding        : var(--spacing-1);
+  color          : var(--bg-color-darker);
+  text-decoration: none;
+  order          : 1;
+}
+
+.nav__back-link:hover {
+  text-decoration: underline;
+}
+
+.nav__title {
+  order: 2;
+}
+
+.nav__mobile-menu {
+  order: 3;
+}
+
+.nav__mobile-dropdown {
+  position        : absolute;
+  top             : 4rem;
+  right           : 0;
+  z-index         : 1000;
+  padding         : var(--spacing-4);
+  border          : 1px solid var(--bg-color-dark);
+  border-radius   : var(--border-radius-xl);
+  background-color: var(--bg-color);
+  min-width       : 16rem;
+  box-shadow      : 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+}
+
+.nav__main {
+  display: none;
+}
+
+.nav__footer {
+  display        : flex;
+  justify-content: end;
+  align-items    : center;
+  margin-top     : var(--spacing-4);
+}
+
+.nav__footer a {
+  padding        : var(--spacing-1);
+  color          : var(--bg-color-darker);
+  text-decoration: none;
+}
+
+.nav__footer a:hover {
+  text-decoration: underline;
+}
+
+@media (min-width: 768px) {
+  .nav__title {
+    order: 1;
+  }
+
+  .nav__back-link {
+    order: 2;
+  }
+
+  .nav__mobile-menu {
+    display: none;
+  }
+
+  .nav__main {
+    display: initial;
+  }
+}

--- a/app/assets/stylesheets/madmin/normalize.css
+++ b/app/assets/stylesheets/madmin/normalize.css
@@ -1,0 +1,213 @@
+/*! modern-normalize v3.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/*
+Document
+========
+*/
+
+/**
+Use a better box model (opinionated).
+*/
+
+*,
+::before,
+::after {
+	box-sizing: border-box;
+}
+
+html {
+	/* Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3) */
+	font-family:
+		system-ui,
+		'Segoe UI',
+		Roboto,
+		Helvetica,
+		Arial,
+		sans-serif,
+		'Apple Color Emoji',
+		'Segoe UI Emoji';
+	line-height: 1.15; /* 1. Correct the line height in all browsers. */
+	-webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
+	tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
+}
+
+/*
+Sections
+========
+*/
+
+body {
+	margin: 0; /* Remove the margin in all browsers. */
+}
+
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct font weight in Chrome and Safari.
+*/
+
+b,
+strong {
+	font-weight: bolder;
+}
+
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+	font-family:
+		ui-monospace,
+		SFMono-Regular,
+		Consolas,
+		'Liberation Mono',
+		Menlo,
+		monospace; /* 1 */
+	font-size: 1em; /* 2 */
+}
+
+/**
+Add the correct font size in all browsers.
+*/
+
+small {
+	font-size: 80%;
+}
+
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+	font-size: 75%;
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
+}
+
+sub {
+	bottom: -0.25em;
+}
+
+sup {
+	top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+	border-color: currentcolor;
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+	font-family: inherit; /* 1 */
+	font-size: 100%; /* 1 */
+	line-height: 1.15; /* 1 */
+	margin: 0; /* 2 */
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+	-webkit-appearance: button;
+}
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+	padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+	vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+	height: auto;
+}
+
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+	-webkit-appearance: textfield; /* 1 */
+	outline-offset: -2px; /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+	-webkit-appearance: none;
+}
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+::-webkit-file-upload-button {
+	-webkit-appearance: button; /* 1 */
+	font: inherit; /* 2 */
+}
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+	display: list-item;
+}

--- a/app/assets/stylesheets/madmin/pages.css
+++ b/app/assets/stylesheets/madmin/pages.css
@@ -1,0 +1,95 @@
+.page-header {
+  display        : initial;
+  justify-content: space-between;
+  align-items    : center;
+  gap            : var(--spacing-4);
+  margin-bottom  : var(--spacing-4);
+}
+
+.page-header a {
+  color          : var(--color-primary);
+  text-decoration: none;
+}
+
+.actions {
+  display        : flex;
+  justify-content: space-between;
+  align-items    : center;
+  gap            : var(--spacing-4);
+  margin-bottom  : var(--spacing-4);
+}
+
+.search-form {
+  position: relative;
+}
+
+.search-form input {
+  flex-grow    : 1;
+  border-radius: var(--border-radius-full);
+  padding      : var(--spacing-2) var(--spacing-4);
+  line-height  : 1.5rem;
+}
+
+.search-clear {
+  display        : flex;
+  position       : absolute;
+  top            : 50%;
+  right          : var(--spacing-4);
+  justify-content: center;
+  align-items    : center;
+  transform      : translateY(-50%);
+}
+
+.scopes {
+  display      : flex;
+  gap          : var(--spacing-2);
+  margin-bottom: var(--spacing-4);
+}
+
+
+@media (min-width: 768px) {
+  .page-header {
+    display: flex;
+  }
+}
+
+
+.attribute-list > * + * {
+  border-top: 1px solid var(--bg-color-dark);
+}
+
+.attribute-item {
+  padding: 0.75rem 1rem;
+}
+
+.attribute-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--bg-color-darker);
+}
+
+.attribute-value {
+  margin-top: 0.5rem;
+}
+
+.attribute-value img {
+  max-height: 8rem;
+}
+
+.attribute-value a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+@media (min-width: 768px) {
+  .attribute-item {
+    display: grid;
+    grid-template-columns: 1fr 3fr;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+  }
+
+  .attribute-value {
+    margin-top: 0;
+  }
+}

--- a/app/assets/stylesheets/madmin/pagy.css
+++ b/app/assets/stylesheets/madmin/pagy.css
@@ -1,0 +1,65 @@
+.pagy {
+  display      : inline-flex;
+  margin-top   : var(--spacing-4);
+  border-radius: 0.375rem;
+  isolation    : isolate;
+}
+
+.pagy a {
+  display         : inline-flex;
+  position        : relative;
+  align-items     : center;
+  margin-left     : -1px;
+  border          : 1px solid var(--bg-color-dark);
+  background-color: var(--bg-color);
+  padding         : var(--spacing-2) var(--spacing-3);
+  color           : var(--bg-color-darker);
+  font-weight     : 600;
+  font-size       : 0.875rem;
+  text-decoration : none;
+}
+
+.pagy a:first-child {
+  border-top-left-radius   : var(--border-radius);
+  border-bottom-left-radius: var(--border-radius);
+}
+
+.pagy a:first-child[aria-disabled="true"]:hover,
+.pagy a:last-child[aria-disabled="true"]:hover {
+  background-color: var(--bg-color);
+}
+
+.pagy a:last-child {
+  border-top-right-radius   : var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
+}
+
+.pagy a:hover {
+  z-index         : 1;
+  background-color: var(--bg-color-dark);
+}
+
+.pagy a:not([href]) {
+  cursor: default;
+  color : var(--bg-color-dark);
+}
+
+.pagy a.current {
+  z-index         : 2;
+  border-color    : var(--color-primary);
+  background-color: var(--color-primary);
+  color           : white;
+}
+
+.pagy label {
+  display         : inline-block;
+  border-radius   : var(--border-radius);
+  background-color: var(--bg-color-dark);
+  padding         : var(--spacing-1) var(--spacing-3);
+}
+
+.pagy label input {
+  border          : none;
+  border-radius   : var(--border-radius);
+  background-color: var(--bg-color);
+}

--- a/app/assets/stylesheets/madmin/tables.css
+++ b/app/assets/stylesheets/madmin/tables.css
@@ -1,0 +1,37 @@
+.table {
+  border-spacing: 0;
+  width         : 100%;
+}
+
+.table-container {
+  margin-bottom: var(--spacing-4);
+  overflow-x   : auto;
+}
+
+.table__header {
+  padding       : var(--spacing-2) var(--spacing-4);
+  border-bottom : 1px solid var(--bg-color-darker);
+  color         : var(--bg-color-darker);
+  font-size     : 1rem;
+  text-transform: uppercase;
+  text-align    : left;
+}
+
+.table__header a {
+  color          : var(--bg-color-darker);
+  text-decoration: none;
+}
+
+.table__header--actions,
+.table__cell--actions {
+  text-align: right;
+}
+
+.table__cell {
+  padding      : var(--spacing-2) var(--spacing-4);
+  border-bottom: 1px solid var(--bg-color-dark);
+}
+
+.table__cell img {
+  max-height: 4rem;
+}

--- a/app/assets/stylesheets/madmin/typography.css
+++ b/app/assets/stylesheets/madmin/typography.css
@@ -1,0 +1,20 @@
+h1 {
+  margin-top   : 0;
+  margin-bottom: var(--spacing-5);
+  font-weight  : 800;
+  font-size    : 2.15em;
+  line-height  : 1.1111111;
+}
+
+p {
+  margin-bottom: var(--spacing-4);
+}
+
+code {
+  border-radius   : var(--border-radius);
+  background-color: var(--bg-color);
+  padding         : var(--spacing-1);
+  font-weight     : 600;
+  font-size       : 0.875rem;
+  font-family     : var(--font-mono);
+}

--- a/app/assets/stylesheets/madmin/utilities.css
+++ b/app/assets/stylesheets/madmin/utilities.css
@@ -1,0 +1,113 @@
+/* Buttons */
+
+.btn {
+  display         : inline-block;
+  padding         : var(--spacing-2) var(--spacing-4);
+  border          : 1px solid var(--bg-color-dark);
+  border-radius   : var(--border-radius);
+  background-color: var(--bg-color);
+  color           : var(--bg-color-darker);
+  font-weight     : 600;
+  text-decoration : none;
+  box-shadow      : 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  line-height     : 1;
+  cursor          : pointer;
+}
+
+.btn-small {
+  padding: var(--spacing-1) var(--spacing-2);
+}
+
+.btn:focus,
+.btn:hover {
+  transform: scale(0.98);
+  filter   : brightness(0.95);
+}
+
+.btn-danger {
+  background-color: var(--color-danger) !important;
+  border-color: var(--color-danger) !important;
+  color       : var(--foreground-color) !important;
+}
+
+.btn-primary {
+  background-color: var(--color-primary) !important;
+  color           : var(--foreground-color) !important;
+}
+
+/* Utilities */
+
+.icon {
+  width : 1.25rem;
+  height: 1.25rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.sr-only {
+  position   : absolute;
+  margin     : -1px;
+  padding    : 0;
+  border     : 0;
+  width      : 1px;
+  height     : 1px;
+  white-space: nowrap;
+  overflow   : hidden;
+  clip       : rect(0, 0, 0, 0);
+}
+
+.mobile-hidden {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .mobile-hidden {
+    display: initial;
+  }
+}
+
+/* Transitions for Tailwind dropdown (should be removed when Tailwind is completely removed) */
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
+.duration-100 {
+  transition-duration: 100ms;
+}
+
+.duration-75 {
+  transition-duration: 75ms;
+}
+
+.ease-out {
+  transition-timing-function: ease-out;
+}
+
+.ease-in {
+  transition-timing-function: ease-in;
+}
+
+.ease-in-out {
+  transition-timing-function: ease-in-out;
+}
+
+.scale-95 {
+  transform: scale(0.95);
+}
+
+.scale-100 {
+  transform: scale(1);
+}
+
+.transition {
+  transition-property       : color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration       : 150ms;
+}

--- a/app/assets/stylesheets/madmin/variables.css
+++ b/app/assets/stylesheets/madmin/variables.css
@@ -1,0 +1,30 @@
+:root {
+  --color-primary  : #63a6e6;
+  --color-secondary: #5e8cb9;
+  --color-success  : #96b57b;
+  --color-danger   : #b75f68;
+  --color-warning  : #e0c184;
+  --color-info     : #6e73ac;
+
+  --bg-color        : #fdfeff;
+  --bg-color-dark   : #d7dbe0;
+  --bg-color-darker : #959aa2;
+  --foreground-color: #1a202c;
+
+  --font-sans : system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono : Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-3: 0.75rem;
+  --spacing-4: 1rem;
+  --spacing-5: 1.5rem;
+
+  --border-radius     : 0.25rem;
+  --border-radius-lg  : 0.5rem;
+  --border-radius-xl  : 1.25rem;
+  --border-radius-full: 9999px;
+
+  --sidebar-width: 17rem;
+}

--- a/app/views/layouts/madmin/application.html.erb
+++ b/app/views/layouts/madmin/application.html.erb
@@ -12,12 +12,12 @@
 
     <%= render "javascript" %>
   </head>
-  <body class="min-h-screen">
-    <div class="md:flex w-full min-h-screen">
-      <div id="sidebar" class="md:w-64 p-4 flex-shrink-0 border-r">
+  <body>
+    <div id="container">
+      <div id="sidebar">
         <%= render "navigation" -%>
       </div>
-      <main class="flex-grow p-4 overflow-x-scroll" role="main">
+      <main role="main">
         <%#= render "flashes" -%>
         <%= yield %>
       </main>

--- a/app/views/madmin/application/_form.html.erb
+++ b/app/views/madmin/application/_form.html.erb
@@ -1,25 +1,27 @@
-<%= form_with model: [:madmin, record], url: (record.persisted? ? resource.show_path(record) : resource.index_path), local: true do |form| %>
+<%= form_with model: [:madmin, record], url: (record.persisted? ? resource.show_path(record) : resource.index_path), local: true, class: "form" do |form| %>
   <% if form.object.errors.any? %>
-    <div class="mb-4 rounded-md text-sm text-red-700 bg-red-100 p-4">
-      <div class="mb-2 font-medium leading-5 text-red-800">There was <%= pluralize form.object.errors.full_messages.count, "error" %> with your submission</div>
+    <div class="form-error">
+      <div class="form-error__summary">There was <%= pluralize form.object.errors.full_messages.count, "error" %> with your submission</div>
 
       <% form.object.errors.full_messages.each do |message| %>
-        <div class="ml-4"><%= message %></div>
+        <div class="form-error__item"><%= message %></div>
       <% end %>
     </div>
   <% end %>
 
   <% resource.attributes.values.select{ _1.field.present? && _1.field.visible?(action_name) }.each do |attribute| %>
-    <div class="mb-4 md:flex">
-      <div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+    <div class="form-group">
+      <div class="form-group__label-container">
         <%= render "madmin/shared/label", form: form, field: attribute.field %>
+        <br />
+        <small><%= attribute.type %></small>
       </div>
-      <div class="flex-1">
+      <div class="form-group__field-container">
         <%= render partial: attribute.field.to_partial_path("form"), locals: { field: attribute.field, record: record, form: form, resource: resource } %>
-        <%= tag.div attribute.field.options.description, class: "text-sm text-gray-700" %>
+        <%= tag.div attribute.field.options.description, class: "form-group__field-description" %>
       </div>
     </div>
   <% end %>
 
-  <%= form.submit class: "bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow" %>
+  <%= form.submit class: "btn btn-primary form__submit" %>
 <% end %>

--- a/app/views/madmin/application/_javascript.html.erb
+++ b/app/views/madmin/application/_javascript.html.erb
@@ -1,39 +1,8 @@
-<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"></script>
+
 <%= stylesheet_link_tag "madmin/application", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/flatpickr/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/trix/dist/trix.css", "data-turbo-track": "reload" %>
 <%= stylesheet_link_tag "https://unpkg.com/tom-select/dist/css/tom-select.min.css", "data-turbo-track": "reload" %>
-<style type="text/tailwindcss">
-.pagy {
-  @apply isolate inline-flex rounded-md;
-
-  a:first-child {
-    @apply rounded-l-md;
-  }
-  a:last-child {
-    @apply rounded-r-md;
-  }
-
-  a {
-    @apply relative -ml-px inline-flex items-center bg-white px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-100 focus:z-10;
-
-    &:not([href]) {
-      @apply text-gray-300 cursor-default;
-    }
-
-    &.current {
-      @apply text-white bg-blue-500 ring-blue-500;
-    }
-  }
-
-  label {
-    @apply inline-block whitespace-nowrap bg-gray-200 rounded-lg px-3 py-0.5;
-    input {
-      @apply bg-gray-100 border-none rounded-md;
-    }
-  }
-}
-</style>
 
 <script type="importmap" data-turbo-track="reload">
   {

--- a/app/views/madmin/application/_menu_resources.html.erb
+++ b/app/views/madmin/application/_menu_resources.html.erb
@@ -1,9 +1,9 @@
-<%= nav_link_to "Dashboard", main_app.madmin_root_path, class: "block p-2 rounded hover:bg-gray-100", active_class: "font-bold text-black" %>
+<%= nav_link_to "Dashboard", main_app.madmin_root_path, class: "nav__link", active_class: "nav__link--active" %>
 
 <% Madmin.resources.each do |resource| %>
-  <%= nav_link_to resource.friendly_name.pluralize, resource.index_path, class: "block p-2 rounded hover:bg-gray-100", starts_with: resource.index_path, active_class: "font-bold text-black" %>
+  <%= nav_link_to resource.friendly_name.pluralize, resource.index_path, class: "nav__link", starts_with: resource.index_path, active_class: "nav__link--active" %>
 <% end %>
 
-<div class="mt-auto">
-  <%= link_to "View Madmin on GitHub", "https://github.com/excid3/madmin", target: :_blank, class: "block p-2 rounded text-gray-500 hover:bg-gray-100" %>
+<div class="nav__footer">
+  <%= link_to "View Madmin on GitHub", "https://github.com/excid3/madmin", target: :_blank %>
 </div>

--- a/app/views/madmin/application/_navigation.html.erb
+++ b/app/views/madmin/application/_navigation.html.erb
@@ -1,29 +1,27 @@
-<div class="flex flex-col h-full text-sm">
-  <div class="flex md:block justify-between items-center">
-    <div class="flex md:block items-center">
-      <h1 class="mr-2 md:p-2 text-xl font-semibold">Madmin</h1>
+<div class="nav">
+    <div class="nav__header">
+      <h1 class="nav__title">Madmin</h1>
       <% if main_app.respond_to?(:root_url) %>
-        <%= link_to main_app.root_url, class: "block p-2 rounded hover:bg-gray-200", data: { turbo: false } do %>
-          ← Back <span class="hidden md:inline">to App</span>
+        <%= link_to main_app.root_url, class: "nav__back-link", data: { turbo: false } do %>
+          ← Back <span class="mobile-hidden">to App</span>
         <% end %>
       <% end %>
+
+        <div class="nav__mobile-menu" data-controller="dropdown">
+          <button data-action="click->dropdown#toggle touch->dropdown#toggle click@window->dropdown#hide touch@window#dropdown->hide" type="button" class="nav__link" id="main-menu" aria-haspopup="true">
+            <span class="sr-only">Open main menu</span>
+            <!-- Heroicon name: outline/menu -->
+            <svg class="icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+          </button>
+          <div class="nav__mobile-dropdown" data-dropdown-target="menu">
+            <%= render "menu_resources" %>
+          </div>
+        </div>
     </div>
 
-    <div class="-mr-2 flex items-center md:hidden relative" data-controller="dropdown">
-      <button data-action="click->dropdown#toggle touch->dropdown#toggle click@window->dropdown#hide touch@window#dropdown->hide" type="button" class="bg-white rounded-md p-2 inline-flex items-center justify-center text-gray-400 hover:bg-gray-200 focus:outline-none focus:ring-2 focus-ring-inset focus:ring-white" id="main-menu" aria-haspopup="true">
-        <span class="sr-only">Open main menu</span>
-        <!-- Heroicon name: outline/menu -->
-        <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-        </svg>
-      </button>
-
-      <div class="absolute top-12 right-0 bg-white rounded-lg min-w-64 shadow-lg hidden md:flex flex-col flex-grow justify-between" data-dropdown-target="menu">
-        <%= render "menu_resources" %>
-      </div>
-    </div>
-    <div class="hidden md:block">
+    <div class="nav__main">
       <%= render "menu_resources" %>
     </div>
-  </div>
 </div>

--- a/app/views/madmin/application/edit.html.erb
+++ b/app/views/madmin/application/edit.html.erb
@@ -1,7 +1,9 @@
-<h1 class="text-xl mb-4">
-  <%= link_to resource.friendly_name.pluralize, resource.index_path, class: "text-blue-500" %>
-  /
-  <strong>Edit <%= link_to resource.display_name(@record), resource.show_path(@record), class: "text-blue-500" %></strong>
-</h1>
+<header class="page-header">
+  <h1>
+    <%= link_to resource.friendly_name.pluralize, resource.index_path %>
+    /
+    <strong>Edit <%= link_to resource.display_name(@record), resource.show_path(@record) %></strong>
+  </h1>
+</header>
 
 <%= render partial: "form", locals: { record: @record, resource: resource } %>

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -1,62 +1,64 @@
-<div class="md:flex justify-between items-center space-y-4 md:space-y-0">
-  <h1 class="text-xl font-semibold"><%= resource.friendly_name.pluralize %></h1>
+<header class="page-header">
+  <h1><%= resource.friendly_name.pluralize %></h1>
 
-  <div class="flex-grow flex md:justify-end gap-4">
-    <form class="flex items-center gap-2 relative">
+  <div class="actions">
+    <form class="search-form">
       <%= hidden_field_tag :page, params[:page], value: 1, class: "hidden" %>
-      <%= search_field_tag :q, params[:q], placeholder: "Search", class: "rounded-full px-4 focus:bg-white focus:border-blue-500" %>
-      <%= link_to clear_search_params, class: "absolute top-1/2 right-3 text-gray-500 bg-white transform -translate-y-1/2" do %>
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+      <%= search_field_tag :q, params[:q], placeholder: "Search", class: "form-input" %>
+      <%= link_to clear_search_params, class: "search-clear" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="icon" viewBox="0 0 20 20" fill="currentColor">
           <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
         </svg>
       <% end %>
     </form>
 
-    <%= link_to resource.new_path, class: "bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow" do %>
-      New <span class="hidden md:inline"><%= resource.friendly_name %></span>
+    <%= link_to resource.new_path, class: "btn btn-primary" do %>
+      New <span class="mobile-hidden"><%= resource.friendly_name %></span>
     <% end %>
   </div>
-</div>
+</header>
 
-<div class="mb-4">
-  <% if resource.scopes.any? %>
-    <%= link_to "All", resource.index_path, class: class_names("p-2 rounded", {"bg-gray-100" =>  params[:scope].blank?}) %>
-  <% end %>
+<% if resource.scopes.any? %>
+  <div class="scopes">
+      <%= link_to "All", resource.index_path, class: class_names("nav__link", {"nav__link--active" =>  params[:scope].blank?}) %>
 
-  <% resource.scopes.each do |scope| %>
-    <%= link_to scope.to_s.humanize, resource.index_path(scope: scope), class: class_names("p-2 rounded", {"bg-gray-100" => params[:scope] == scope.to_s}) %>
-  <% end %>
-</div>
-<div class="min-w-full max-w-xl overflow-x-auto pb-4">
-  <table class="min-w-full divide-y divide-gray-200">
+    <% resource.scopes.each do |scope| %>
+      <%= link_to scope.to_s.humanize, resource.index_path(scope: scope), class: class_names("nav__link", {"nav__link--active" => params[:scope] == scope.to_s}) %>
+    <% end %>
+  </div>
+<% end %>
+
+<div class="table-container">
+  <table class="table">
     <thead>
-      <tr class="border-b border-gray-200">
+      <tr>
         <% resource.attributes.values.each do |attribute| %>
           <% next if attribute.field.nil? %>
           <% next unless attribute.field.visible?(action_name) %>
 
-          <th class="py-2 px-4 text-left text-xs text-gray-500 font-medium uppercase whitespace-nowrap"><%= sortable attribute.name, attribute.name.to_s.titleize %></th>
+          <th class="table__header"><%= sortable attribute.name, attribute.name.to_s.titleize %></th>
         <% end %>
-        <th class="py-2 px-4 text-right text-xs text-gray-500 font-medium uppercase"></th>
+        <th class="table__header table__header--actions"></th>
       </tr>
     </thead>
 
-    <tbody class="text-sm divide-y">
+    <tbody>
       <% @records.each do |record| %>
         <tr>
           <% resource.attributes.values.each do |attribute| %>
             <% next if attribute.field.nil? %>
             <% next unless attribute.field.visible?(action_name) %>
-            <td class="px-4 py-2"><%= render partial: attribute.field.to_partial_path("index"), locals: { field: attribute.field, record: record, resource: resource } %></td>
+            <td class="table__cell"><%= render partial: attribute.field.to_partial_path("index"), locals: { field: attribute.field, record: record, resource: resource } %></td>
           <% end %>
 
-          <td class="px-4 py-2 text-right">
-            <%= link_to "View", resource.show_path(record), class: "inline-block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-1 px-2 border border-gray-400 rounded shadow" %>
-            <%= link_to "Edit", resource.edit_path(record), class: "inline-block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-1 px-2 border border-gray-400 rounded shadow" %>
+          <td class="table__cell table__cell--actions">
+            <%= link_to "View", resource.show_path(record), class: "btn btn-small" %>
+            <%= link_to "Edit", resource.edit_path(record), class: "btn btn-small" %>
           </td>
         </tr>
       <% end %>
     </tbody>
   </table>
 </div>
+
 <%== pagy_nav @pagy %>

--- a/app/views/madmin/application/new.html.erb
+++ b/app/views/madmin/application/new.html.erb
@@ -1,7 +1,9 @@
-<h1 class="text-xl mb-4">
-  <%= link_to resource.friendly_name.pluralize, resource.index_path, class: "text-blue-500" %>
-  /
-  <strong>New <%= resource.friendly_name %></strong>
-</h1>
+<header class="page-header">
+  <h1>
+    <%= link_to resource.friendly_name.pluralize, resource.index_path %>
+    /
+    <strong>New <%= resource.friendly_name %></strong>
+  </h1>
+</header>
 
 <%= render partial: "form", locals: { record: @record, resource: resource } %>

--- a/app/views/madmin/application/show.html.erb
+++ b/app/views/madmin/application/show.html.erb
@@ -1,30 +1,30 @@
-<div class="md:flex items-center justify-between mb-4">
-  <h1 class="text-xl">
-    <%= link_to resource.friendly_name.pluralize, resource.index_path, class: "text-blue-500" %>
+<header class="page-header">
+  <h1>
+    <%= link_to resource.friendly_name.pluralize, resource.index_path %>
     /
-    <%= link_to resource.display_name(@record), resource.show_path(@record), class: "text-blue-500 font-bold" %>
+    <strong><%= link_to resource.display_name(@record), resource.show_path(@record) %></strong>
   </h1>
 
-  <div class="flex gap-2 items-center px-4">
+  <div class="actions">
     <% resource.member_actions.each do |action| %>
-      <%= instance_eval(&action)  %>
+      <%= instance_eval(&action) %>
     <% end %>
-    <%= link_to "Edit", resource.edit_path(@record), class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow" %>
-    <%= button_to "Delete", resource.show_path(@record), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "bg-white hover:bg-gray-100 text-red-500 font-semibold py-2 px-4 border border-red-500 rounded shadow pointer-cursor" %>
+    <%= link_to "Edit", resource.edit_path(@record), class: "btn btn-primary" %>
+    <%= button_to "Delete", resource.show_path(@record), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "btn btn-danger" %>
   </div>
-</div>
+</header>
 
-<div class="divide-y">
+<div class="attribute-list">
   <% resource.attributes.values.each do |attribute| %>
     <% next if attribute.field.nil? %>
     <% next unless attribute.field.visible?(action_name) %>
 
-    <div class="px-4 py-3 md:grid md:grid-cols-4 md:gap-4 md:px-6">
-      <div class="text-sm font-medium text-gray-500">
+    <div class="attribute-item">
+      <div class="attribute-label">
         <%= attribute.field.options.label || attribute.name.to_s.titleize %>
       </div>
 
-      <div class="md:col-span-3">
+      <div class="attribute-value">
         <%= render partial: attribute.field.to_partial_path("show"), locals: { field: attribute.field, record: @record, resource: resource } %>
       </div>
     </div>

--- a/app/views/madmin/dashboard/show.html.erb
+++ b/app/views/madmin/dashboard/show.html.erb
@@ -1,4 +1,4 @@
-<div class="prose">
+<div>
   <h1>Madmin Dashboard</h1>
   <p>Create <code>app/views/madmin/dashboard/show.html.erb</code> to customize your dashboard.</p>
 </div>

--- a/app/views/madmin/fields/attachment/_form.html.erb
+++ b/app/views/madmin/fields/attachment/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form.file_field field.to_param %>
-<div class="mt-2">
+<div>
   <%= render partial: field.to_partial_path("show"), locals: {field: field, record: record} %>
 
   <% if (value = field.value(record) && value&.attached?) %>

--- a/app/views/madmin/fields/attachment/_index.html.erb
+++ b/app/views/madmin/fields/attachment/_index.html.erb
@@ -1,6 +1,6 @@
 <% if (attachment = field.value(record)) && attachment.attached? %>
   <% if attachment.variable? %>
-    <%= image_tag main_app.url_for(attachment), class: "max-h-8" %>
+    <%= image_tag main_app.url_for(attachment) %>
   <% else %>
     <%= attachment.filename %>
   <% end %>

--- a/app/views/madmin/fields/attachment/_show.html.erb
+++ b/app/views/madmin/fields/attachment/_show.html.erb
@@ -1,8 +1,8 @@
 <% if (attachment = field.value(record)) && attachment.attached? %>
   <% if attachment.variable? %>
-    <%= image_tag main_app.url_for(attachment), class: "max-h-32" %>
+    <%= image_tag main_app.url_for(attachment) %>
   <% else %>
-    <%= link_to attachment.filename, main_app.url_for(attachment), target: :_blank, class: "text-blue-500 underline" %>
+    <%= link_to attachment.filename, main_app.url_for(attachment), target: :_blank %>
   <% end %>
 
   <%= link_to "Remove", Madmin.resource_for(attachment).show_path(attachment), data: { turbo_method: :delete, turbo_confirm: "Are you sure? You will lose any other changes."} %>

--- a/app/views/madmin/fields/attachments/_show.html.erb
+++ b/app/views/madmin/fields/attachments/_show.html.erb
@@ -2,10 +2,10 @@
   <% attachments.each do |attachment| %>
     <% if attachment.variable? %>
       <%= link_to main_app.url_for(attachment), target: :_blank do %>
-        <%= image_tag main_app.url_for(attachment), class: "max-h-32" %>
+        <%= image_tag main_app.url_for(attachment) %>
       <% end %>
     <% else %>
-      <%= link_to attachment.filename, main_app.url_for(attachment), target: :_blank, class: "text-blue-500 underline" %>
+      <%= link_to attachment.filename, main_app.url_for(attachment), target: :_blank %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/madmin/fields/belongs_to/_show.html.erb
+++ b/app/views/madmin/fields/belongs_to/_show.html.erb
@@ -1,3 +1,3 @@
 <% if (object = field.value(record)) %>
-  <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object), class: "text-blue-500 underline" %>
+  <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object) %>
 <% end %>

--- a/app/views/madmin/fields/file/_show.html.erb
+++ b/app/views/madmin/fields/file/_show.html.erb
@@ -1,6 +1,6 @@
 <% value = field.value(record) %>
 <% if value.respond_to?(:url) %>
-  <%= link_to value.url, value.url, target: :_blank, class: "text-blue-500 underline" %>
+  <%= link_to value.url, value.url, target: :_blank %>
 <% else %>
   <%= value %>
 <% end %>

--- a/app/views/madmin/fields/has_many/_show.html.erb
+++ b/app/views/madmin/fields/has_many/_show.html.erb
@@ -1,5 +1,5 @@
 <% field.value(record).each do |object| %>
   <div>
-    <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object), class: "text-blue-500 underline" %>
+    <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object) %>
   </div>
 <% end %>

--- a/app/views/madmin/fields/nested_has_many/_fields.html.erb
+++ b/app/views/madmin/fields/nested_has_many/_fields.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, class: "nested-fields border border-gray-200 rounded-lg p-5", data: { new_record: f.object.new_record? } do %>
+<%= content_tag :div, class: "nested-fields", data: { new_record: f.object.new_record? } do %>
   <% field.nested_attributes.each do |name, nested_attribute| %>
     <% next if nested_attribute[:field].nil? %>
     <% next unless nested_attribute[:field].visible?(action_name) %>
@@ -6,7 +6,7 @@
 
     <% nested_field = nested_attribute[:field] %>
 
-    <div class="mb-4 flex">
+    <div class="nested-fields__field">
       <%= render partial: nested_field.to_partial_path("form"), locals: { field: nested_field, record: f.object, form: f, resource: field.resource } %>
     </div>
   <% end %>

--- a/app/views/madmin/fields/nested_has_many/_form.html.erb
+++ b/app/views/madmin/fields/nested_has_many/_form.html.erb
@@ -1,8 +1,8 @@
-<div class="block md:inline-block w-32 flex-shrink-0">
+<div class="form-group__label-container">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
 
-<div class="container space-y-8" data-controller="nested-form">
+<div class="form-group__nested-form" data-controller="nested-form">
   <template data-target="nested-form.template">
 
     <%= form.fields_for field.attribute_name, field.to_model.new, child_index: 'NEW_RECORD' do |nested_form| %>

--- a/app/views/madmin/fields/nested_has_many/_show.html.erb
+++ b/app/views/madmin/fields/nested_has_many/_show.html.erb
@@ -1,5 +1,5 @@
 <% field.value(record).each do |object| %>
   <div>
-    <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object), class: "text-blue-500 underline" %>
+    <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object) %>
   </div>
 <% end %>

--- a/app/views/madmin/fields/polymorphic/_show.html.erb
+++ b/app/views/madmin/fields/polymorphic/_show.html.erb
@@ -1,3 +1,3 @@
 <% if (object = field.value(record)) %>
-  <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object), class: "text-blue-500 underline" %>
+  <%= link_to Madmin.resource_for(object).display_name(object), Madmin.resource_for(object).show_path(object) %>
 <% end %>

--- a/app/views/madmin/fields/rich_text/_show.html.erb
+++ b/app/views/madmin/fields/rich_text/_show.html.erb
@@ -1,3 +1,1 @@
-<div class="prose">
-  <%= field.value(record) %>
-</div>
+<%= field.value(record) %>

--- a/app/views/madmin/fields/time/_form.html.erb
+++ b/app/views/madmin/fields/time/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+<div class="form-group__label-container">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
 <%= form.time_select field.attribute_name, {}, { class: "form-select" } %>

--- a/app/views/madmin/shared/_label.html.erb
+++ b/app/views/madmin/shared/_label.html.erb
@@ -1,4 +1,4 @@
 <%= form.label field.attribute_name, field.options.label %>
 <% if field.required? %>
-  <span class="text-red-500">*</span>
+  <span class="form__required">*</span>
 <% end %>

--- a/lib/generators/madmin/field/templates/_form.html.erb
+++ b/lib/generators/madmin/field/templates/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
+<div class="form-group__label-container">
   <%= render "madmin/shared/label", form: form, field: field %>
 </div>
 <%= form.text_field field.attribute_name, class: "flex-grow form-input" %>

--- a/test/dummy/app/madmin/resources/post_resource.rb
+++ b/test/dummy/app/madmin/resources/post_resource.rb
@@ -23,20 +23,20 @@ class PostResource < Madmin::Resource
 
   member_action do
     unless @record.published?
-      button_to "Publish", main_app.publish_madmin_post_path(@record), method: :patch, data: { turbo_confirm: "Are you sure?" }, class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow"
+      button_to "Publish", main_app.publish_madmin_post_path(@record), method: :patch, data: { turbo_confirm: "Are you sure?" }, class: "btn"
     end
   end
 
 
   member_action do
     unless @record.draft?
-      button_to "Draft", main_app.draft_madmin_post_path(@record), method: :patch, data: { turbo_confirm: "Are you sure?" }, class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow"
+      button_to "Draft", main_app.draft_madmin_post_path(@record), method: :patch, data: { turbo_confirm: "Are you sure?" }, class: "btn"
     end
   end
 
   member_action do
     unless @record.archived?
-      button_to "Archive", main_app.archive_madmin_post_path(@record), method: :patch, data: { turbo_confirm: "Are you sure?" }, class: "block bg-white hover:bg-gray-100 text-gray-800 font-semibold py-2 px-4 border border-gray-400 rounded shadow"
+      button_to "Archive", main_app.archive_madmin_post_path(@record), method: :patch, data: { turbo_confirm: "Are you sure?" }, class: "btn"
     end
   end
 


### PR DESCRIPTION
This PR implements a structure of pure CSS stylesheets, as suggested by @excid3 in #214, without altering the current design. Key points:

- Removes Tailwind dependencies
- Introduces a maintainable CSS structure
- Good start for future enhancements (e.g., dark mode)

### Notes:
- Dark mode is partially implemented, see `custom.css`, before loading that, a theme toggle button is still needed
- There's room for improvements.

Feedback and suggestions are welcome!

Here it is:

https://github.com/user-attachments/assets/b8a6a4e6-df7b-400b-a9c0-115af2c328a5

