### PR TITLE
Add collection support for belongs_to fields

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,7 +4,8 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin "trix"
 pin "@rails/actiontext", to: "actiontext.esm.js"
-pin_all_from Madmin::Engine.root.join("app/javascript/madmin/controllers"), under: "controllers", to: "madmin/controllers"
+pin_all_from Madmin::Engine.root.join("app/javascript/madmin/controllers"), under: "controllers",
+                                                                            to: "madmin/controllers"
 
-pin "tom-select", to: "https://unpkg.com/tom-select@2/dist/esm/tom-select.complete.js"
+pin "tom-select", to: "https://ga.jspm.io/npm:tom-select@2.4.1/dist/js/tom-select.complete.js"
 pin "tailwindcss-stimulus-components", to: "https://unpkg.com/tailwindcss-stimulus-components@5/dist/tailwindcss-stimulus-components.module.js"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,4 +8,4 @@ pin_all_from Madmin::Engine.root.join("app/javascript/madmin/controllers"), unde
                                                                             to: "madmin/controllers"
 
 pin "tom-select", to: "https://ga.jspm.io/npm:tom-select@2.4.1/dist/js/tom-select.complete.js"
-pin "tailwindcss-stimulus-components", to: "https://unpkg.com/tailwindcss-stimulus-components@5/dist/tailwindcss-stimulus-components.module.js"
+pin "tailwindcss-stimulus-components", to: "https://ga.jspm.io/npm:tailwindcss-stimulus-components@6.1.2/dist/tailwindcss-stimulus-components.module.js"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,8 +4,7 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin "trix"
 pin "@rails/actiontext", to: "actiontext.esm.js"
-pin_all_from Madmin::Engine.root.join("app/javascript/madmin/controllers"), under: "controllers",
-                                                                            to: "madmin/controllers"
+pin_all_from Madmin::Engine.root.join("app/javascript/madmin/controllers"), under: "controllers", to: "madmin/controllers"
 
 pin "tom-select", to: "https://ga.jspm.io/npm:tom-select@2.4.1/dist/js/tom-select.complete.js"
 pin "tailwindcss-stimulus-components", to: "https://ga.jspm.io/npm:tailwindcss-stimulus-components@6.1.2/dist/tailwindcss-stimulus-components.module.js"

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -2,7 +2,13 @@ module Madmin
   module Fields
     class BelongsTo < Field
       def options_for_select(record)
-        if (record = record.send(attribute_name))
+        if options[:collection].present?
+          collection = options[:collection].is_a?(Proc) ? options[:collection].call : options[:collection]
+          collection.map do |item|
+            resource = Madmin.resource_for(item)
+            [resource.display_name(item), item.id]
+          end
+        elsif (record = record.send(attribute_name))
           resource = Madmin.resource_for(record)
           [[resource.display_name(record), record.id]]
         else

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -3,12 +3,12 @@ module Madmin
     class BelongsTo < Field
       def options_for_select(record)
         records = if (record = record.send(attribute_name))
-          [Madmin.resource_for(record)]
+          [record]
         else
           associated_resource.model.first(25)
         end
 
-        records.map { [resource.display_name(_1), _1.id] }
+        records.map { [Madmin.resource_for(_1).display_name(_1), _1.id] }
       end
 
       def to_param

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -2,18 +2,13 @@ module Madmin
   module Fields
     class BelongsTo < Field
       def options_for_select(record)
-        if options[:collection].present?
-          collection = options[:collection].is_a?(Proc) ? options[:collection].call : options[:collection]
-          collection.map do |item|
-            resource = Madmin.resource_for(item)
-            [resource.display_name(item), item.id]
-          end
-        elsif (record = record.send(attribute_name))
-          resource = Madmin.resource_for(record)
-          [[resource.display_name(record), record.id]]
+        records = if (record = record.send(attribute_name))
+          [Madmin.resource_for(record)]
         else
-          []
+          associated_resource.model.first(25)
         end
+
+        records.map { [resource.display_name(_1), _1.id] }
       end
 
       def to_param
@@ -21,7 +16,11 @@ module Madmin
       end
 
       def index_path
-        Madmin.resource_by_name(model.reflect_on_association(attribute_name).klass).index_path(format: :json)
+        associated_resource.index_path(format: :json)
+      end
+
+      def associated_resource
+        Madmin.resource_by_name(model.reflect_on_association(attribute_name).klass)
       end
     end
   end


### PR DESCRIPTION
Fixes #156 & https://github.com/excid3/madmin/issues/176

Currently, belongs_to fields don't show all available options in the dropdown. This PR:

- Updates BelongsTo field to support a collection option for loading all available records
- Updates import map packages to use ga.jspm.io, unpkg did not have tom-select and, from the second issue, tailwind-css-stimulus-components as well

Example usage:
```ruby
class ArticleResource < Madmin::Resource
  attribute :parent_article, collection: -> { Article.all }
end
```

Before: Static select dropdown with only the current selection visible
After: Searchable dropdown showing all available options with filtering

Testing:
	1.	Visit any resource edit page with a belongs_to association
	2.	Verify the dropdown shows all available options when collection is specified
	3.     The collection is searchable
	
	
<img width="723" alt="Screenshot 2024-11-20 at 16 51 28" src="https://github.com/user-attachments/assets/066b72e2-73e2-418c-b0c7-89095e28996c">
