### PR TITLE
avoid raising error when routes/madmin.rb is missing

### DIFF
--- a/lib/madmin/generator_helpers.rb
+++ b/lib/madmin/generator_helpers.rb
@@ -7,7 +7,9 @@ module Madmin
     end
 
     def route_namespace_exists?
-      File.readlines(Rails.root.join(default_routes_file)).grep(/namespace :madmin/).size > 0
+      file = Rails.root.join(default_routes_file)
+
+      File.exist?(file) && File.readlines(file).grep(/namespace :madmin/).size > 0
     end
 
     def rails6_1_and_up?


### PR DESCRIPTION
This is a start to fix https://github.com/excid3/madmin/issues/236 but not complete

There are 3 scenarios:
- I have default config (routes/madmin.rb file and namespace :madmin)
- I have deleted routes/madmin.rb, but I still have namespace :madmin - this is my case
- I have deleted routes/madmin.rb and I renamed the namespace

In my case, running generate resource was raising a file missing exception in File.readlines

This PR fixes just that exception - if you don't have a madmin.rb file you shouldn't expect having the resource added there

Sorry, I know it's not that much of a big contribution 😞 