### PR TITLE
Include url helpers to the template generator

### DIFF
--- a/lib/generators/madmin/install/templates/controller.rb.tt
+++ b/lib/generators/madmin/install/templates/controller.rb.tt
@@ -1,5 +1,6 @@
 module Madmin
   class ApplicationController < Madmin::BaseController
+    include Rails.application.routes.url_helpers
     before_action :authenticate_admin_user
 
     def authenticate_admin_user


### PR DESCRIPTION
Users will have to manually add the url helpers module right after doing the templates generation.

### Description
Running `rails generate madmin:install` should copy the exact contents of madmin/application_controller.rb which includes the URL helpers.