### PR TITLE
Update Madmin docs with updated information to keep non admins out

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,5 +1,15 @@
 # Authenticating Madmin
 
+The first place to look to secure your madmin panel after installation is inside of app/controllers/madmin/application_controller.rb
+Inside of there you can add something along the lines of:
+
+def authenticate_admin_user
+  # other stuff
+  redirect_to "/", alert: "Not authorized." unless current_user&.admin?
+end  
+
+That may likely be sufficient to keep non-admin Users out of your madmin panels. Testing access to the /madmin route an pane in an ingognito window is a great way to test this change.
+
 ### Devise Routes
 
 Wrap the madmin routes in an `authenticated` or `authenticate` block:

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -3,10 +3,12 @@
 The first place to look to secure your madmin panel after installation is inside of app/controllers/madmin/application_controller.rb
 Inside of there you can add something along the lines of:
 
+```
 def authenticate_admin_user
   # other stuff
   redirect_to "/", alert: "Not authorized." unless current_user&.admin?
-end  
+end
+```
 
 That may likely be sufficient to keep non-admin Users out of your madmin panels. Testing access to the /madmin route an pane in an ingognito window is a great way to test this change.
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,7 +10,7 @@ def authenticate_admin_user
 end
 ```
 
-That may likely be sufficient to keep non-admin Users out of your madmin panels. Testing access to the /madmin route an pane in an ingognito window is a great way to test this change.
+That may likely be sufficient to keep non-admin Users out of your madmin panels. Testing access to the /madmin route in an ingognito window (and not logged in as an admin) is an easy way to test this change.
 
 ### Devise Routes
 


### PR DESCRIPTION
It took a bit of digging to figure this out, as the docs and authentication.md did not mention the madmin application controller and the existing authenticate_admin_user method, so I'm suggesting this update to potentially make it easier for the next person. 

Cheers!