### PR TITLE
#268 Ensure that Madmin::Resource.friendly_name honors inflections

### DIFF
--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -74,7 +74,7 @@ module Madmin
       end
 
       def friendly_name
-        model_name.gsub("::", " / ").split(/(?=[A-Z])/).join(" ")
+        model_name.split("::").map { |part| part.underscore.humanize }.join(" / ").titlecase.pluralize
       end
 
       # Support for isolated namespaces

--- a/test/madmin/resource_test.rb
+++ b/test/madmin/resource_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class FooBarBazResource < Madmin::Resource; end
+class FooBarBahResource < Madmin::Resource; end
 
 class ResourceTest < ActiveSupport::TestCase
   test "searchable_attributes" do
@@ -13,7 +13,7 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   test "friendly_name" do
-    assert_equal "User", UserResource.friendly_name
-    assert_equal "Foo Bar Baz", FooBarBazResource.friendly_name
+    assert_equal "Users", UserResource.friendly_name
+    assert_equal "Foo Bar Bahs", FooBarBahResource.friendly_name
   end
 end


### PR DESCRIPTION
Madmin::Resource.friendly_name used to say "Tap Gig Box" instead of "TapGig Box" even though TapGig was a registered acronym.