### PR TITLE
feat: mobile support

### DIFF
--- a/app/assets/stylesheets/madmin/application-sprockets.css
+++ b/app/assets/stylesheets/madmin/application-sprockets.css
@@ -8,4 +8,5 @@
  *= require madmin/forms
  *= require madmin/tables
  *= require madmin/pagination
+ *= require madmin/index_page
 */

--- a/app/assets/stylesheets/madmin/application.css
+++ b/app/assets/stylesheets/madmin/application.css
@@ -7,4 +7,4 @@
 @import url("/madmin/forms.css");
 @import url("/madmin/tables.css");
 @import url("/madmin/pagination.css");
-
+@import url("/madmin/index_page.css");

--- a/app/assets/stylesheets/madmin/base.css
+++ b/app/assets/stylesheets/madmin/base.css
@@ -63,10 +63,12 @@ a {
 .header {
   border-bottom: 1px solid rgb(229 231 235);
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   padding-bottom: 1rem;
   margin-bottom: 1rem;
+  gap: 0.5rem;
 
   h1 {
     margin: 0;
@@ -83,6 +85,7 @@ a {
   .actions {
     align-items: center;
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
   }
 }

--- a/app/assets/stylesheets/madmin/index_page.css
+++ b/app/assets/stylesheets/madmin/index_page.css
@@ -1,0 +1,7 @@
+.index {
+  .trix-content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 300px;
+  }
+}

--- a/app/assets/stylesheets/madmin/sidebar.css
+++ b/app/assets/stylesheets/madmin/sidebar.css
@@ -78,3 +78,58 @@ main {
     }
   }
 }
+
+/* Mobile Navigation Styles */
+#hamburger-menu {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  padding: 0.5rem;
+  cursor: pointer;
+  color: var(--text-color);
+}
+
+.mobile-nav-overlay {
+  opacity: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.15);
+  z-index: 40;
+  transition: 0.2s ease-in-out;
+  pointer-events: none;
+}
+
+.mobile-nav-overlay.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (max-width: 640px) {
+  #hamburger-menu {
+    display: block;
+  }
+
+  main {
+    /* reset padding */
+    padding-left: 1rem;
+  }
+
+  #sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease-in-out;
+    background-color: var(--background-color, #fff);
+    z-index: 50;
+  }
+
+  #sidebar.is-open {
+    transform: translateX(0);
+  }
+}

--- a/app/assets/stylesheets/madmin/tables.css
+++ b/app/assets/stylesheets/madmin/tables.css
@@ -3,6 +3,8 @@
   border: 1px solid var(--border-color);
   overflow-x: auto;
   position: relative;
+  min-width: 0;
+  width: 100%;
 }
 
 table {
@@ -13,10 +15,6 @@ table {
     background-color: var(--background-color);
     border-bottom: 1px solid var(--border-color);
     text-align: left;
-    padding-bottom: 0.75rem;
-    padding-top: 0.75rem;
-    padding-right: 0.875rem;
-    padding-left: 0.875rem;
 
     a {
       color: rgb(17 24 39);
@@ -36,11 +34,6 @@ table {
   }
 
   td {
-    padding-bottom: 0.75rem;
-    padding-top: 0.75rem;
-    padding-right: 0.875rem;
-    padding-left: 0.875rem;
-
     a {
       font-weight: 500;
     }
@@ -52,5 +45,17 @@ table {
     &:last-child {
       border-bottom: none;
     }
+  }
+
+  th, td {
+    /* force scroll */
+    min-width: 60px;
+    white-space: nowrap;
+
+    /* responsive padding */
+    padding-top: clamp(0.5rem, 0.25rem + 1.25vw, 0.75rem);
+    padding-bottom: clamp(0.5rem, 0.25rem + 1.25vw, 0.75rem);
+    padding-left: clamp(0.5rem, 0.125rem + 1.875vw, 0.875rem);
+    padding-right: clamp(0.5rem, 0.125rem + 1.875vw, 0.875rem);
   }
 }

--- a/app/javascript/madmin/controllers/mobile_nav_controller.js
+++ b/app/javascript/madmin/controllers/mobile_nav_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu", "overlay"]
+
+  connect() {
+    this.handleEscape = this.handleEscape.bind(this)
+  }
+
+  toggle() {
+    const isOpen = this.menuTarget.classList.toggle("is-open")
+    this.element.setAttribute("aria-expanded", isOpen)
+    this.toggleOverlay(isOpen)
+    this.toggleBodyScroll(isOpen)
+    this.toggleEscapeListener(isOpen)
+  }
+
+  close() {
+    if (this.menuTarget.classList.contains("is-open")) {
+      this.toggle()
+    }
+  }
+
+  handleEscape(event) {
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  disconnect() {
+    this.toggleEscapeListener(false)
+    this.toggleBodyScroll(false)
+  }
+
+  toggleOverlay(isOpen) {
+    if (this.hasOverlayTarget) {
+      this.overlayTarget.classList.toggle("is-active", isOpen)
+    }
+  }
+
+  toggleBodyScroll(isOpen) {
+    document.body.style.overflow = isOpen ? 'hidden' : ''
+  }
+
+  toggleEscapeListener(isOpen) {
+    const method = isOpen ? 'addEventListener' : 'removeEventListener'
+    document[method]("keydown", this.handleEscape)
+  }
+}

--- a/app/views/layouts/madmin/application.html.erb
+++ b/app/views/layouts/madmin/application.html.erb
@@ -13,13 +13,15 @@
     <%= csrf_meta_tags %>
     <%= render "javascript" %>
   </head>
-  <body>
-    <aside id="sidebar">
+  <body class="<%= controller_name %> <%= action_name %>" data-controller="mobile-nav">
+    <button id="hamburger-menu" type="button" data-action="click->mobile-nav#toggle" aria-label="Open menu" aria-expanded="false" aria-controls="sidebar">☰</button>
+    <aside id="sidebar" data-mobile-nav-target="menu">
       <%= render "navigation" %>
     </aside>
     <main>
       <%= render "flash" %>
       <%= yield %>
     </main>
+    <div data-mobile-nav-target="overlay" data-action="click->mobile-nav#close" class="mobile-nav-overlay"></div>
   </body>
 </html>


### PR DESCRIPTION
Adding mobile support #267 
I tried to be minimal on this one. 

- fluid padding on table
- menu stimulus controller
- menu elements at layout
- truncate content when .trix-content at index view only
- classes at body (controller and action names) 
- header will flex wrap if too big

https://github.com/user-attachments/assets/8e4e03ea-b077-4fd1-97da-dbb7ec9cbef9

