### PR TITLE
Fix duplicate time field label

### DIFF
--- a/app/views/madmin/fields/time/_form.html.erb
+++ b/app/views/madmin/fields/time/_form.html.erb
@@ -1,4 +1,5 @@
-<div class="block md:inline-block md:w-32 flex-shrink-0 text-gray-700">
-  <%= render "madmin/shared/label", form: form, field: field %>
+<div>
+  <%= form.time_select field.attribute_name,
+                       {},
+                       class: "form-select inline-block" %>
 </div>
-<%= form.time_select field.attribute_name, {}, { class: "form-select" } %>


### PR DESCRIPTION
## Summary
This PR cleans up the time-field template by ditching the extra manual label. Now we just wrap the built-in `time_select` in a plain `<div>`, which keeps the hour/minute selects side-by-side and eliminates the double label.

## Screenshots
<img width="128" height="86" alt="Screenshot 2025-07-11 at 2 13 04 p m" src="https://github.com/user-attachments/assets/29b16ac5-d76c-41fa-8c60-4bc2d04b1857" />
