### PR TITLE
Show item range in pagination info

### DIFF
--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -64,5 +64,5 @@
 
 <div class="pagination">
   <%== pagy_nav @pagy if @pagy.pages > 1 %>
-  <span>Showing <%= tag.strong @pagy.in %> of <%= tag.strong @pagy.count %></span>
+  <span>Showing <%= tag.strong "#{@pagy.from}-#{@pagy.to}" %> of <%= tag.strong @pagy.count %></span>
 </div>

--- a/app/views/madmin/fields/has_many/_show.html.erb
+++ b/app/views/madmin/fields/has_many/_show.html.erb
@@ -7,5 +7,5 @@
 
 <div class="pagination">
   <%== pagy_nav pagy if pagy.pages > 1 %>
-  <span>Showing <%= tag.strong pagy.in %> of <%= tag.strong pagy.count %></span>
+  <span>Showing <%= tag.strong "#{@pagy.from}-#{@pagy.to}" %> of <%= tag.strong @pagy.count %></span>
 </div>

--- a/app/views/madmin/fields/nested_has_many/_show.html.erb
+++ b/app/views/madmin/fields/nested_has_many/_show.html.erb
@@ -7,5 +7,5 @@
 
 <div class="pagination">
   <%== pagy_nav pagy if pagy.pages > 1 %>
-  <span>Showing <%= tag.strong pagy.in %> of <%= tag.strong pagy.count %></span>
+  <span>Showing <%= tag.strong "#{@pagy.from}-#{@pagy.to}" %> of <%= tag.strong @pagy.count %></span>
 </div>


### PR DESCRIPTION
## Summary
Instead of “Showing 20 of 101,” this small PR updates the pagination bar to say “Showing 1–20 of 101” by using Pagy’s from and to helpers.