### PR TITLE
Adding a space in the module/project name for visual improvements

### DIFF
--- a/lib/madmin/engine.rb
+++ b/lib/madmin/engine.rb
@@ -11,7 +11,7 @@ module Madmin
 
     config.to_prepare do
       Madmin.reset_resources!
-      Madmin.site_name ||= Rails.application.class.module_parent_name
+      Madmin.site_name ||= Rails.application.class.module_parent_name.titleize
     end
 
     initializer "madmin.assets" do |app|


### PR DESCRIPTION
Fixing: #287

The Module name does not include a space if the project name is two words. This pull request is to add a space between the two words in the Module name for visibility improvements.

## Before Fix ##
<img width="538" height="264" alt="Screenshot 2025-07-26 at 6 53 38 PM" src="https://github.com/user-attachments/assets/6ccc8185-8042-44c3-9df7-327471a91ca7" />

<img width="344" height="80" alt="Screenshot 2025-07-26 at 6 53 45 PM" src="https://github.com/user-attachments/assets/fe7cb734-4b3e-4868-8afb-4037f548925e" />


## After Fix ##
<img width="540" height="271" alt="Screenshot 2025-07-26 at 6 45 04 PM" src="https://github.com/user-attachments/assets/9b7d9e43-c34a-4909-b159-a695af1ace73" />

<img width="299" height="79" alt="Screenshot 2025-07-26 at 6 47 29 PM" src="https://github.com/user-attachments/assets/314003a6-7a6c-418d-87ae-bcfbbde9f97d" />
