### PR TITLE
Singularize friendly resource names

### DIFF
--- a/app/views/madmin/application/_form.html.erb
+++ b/app/views/madmin/application/_form.html.erb
@@ -19,6 +19,6 @@
     </div>
   <% end %>
 
-  <%= form.submit class: "btn btn-primary", title: resource.friendly_name %>
+  <%= form.submit class: "btn btn-primary" %>
   <%= link_to "Cancel", (record.persisted? ? resource.show_path(record) : resource.index_path), class: "btn" %>
 <% end %>

--- a/app/views/madmin/application/_form.html.erb
+++ b/app/views/madmin/application/_form.html.erb
@@ -19,6 +19,6 @@
     </div>
   <% end %>
 
-  <%= form.submit class: "btn btn-primary" %>
+  <%= form.submit class: "btn btn-primary", title: resource.friendly_name %>
   <%= link_to "Cancel", (record.persisted? ? resource.show_path(record) : resource.index_path), class: "btn" %>
 <% end %>

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -71,8 +71,8 @@ module Madmin
         )
       end
 
-       # Returns singular name
-       # For example: "Forum::Post" -> "Forum / Post"
+      # Returns singular name
+      # For example: "Forum::Post" -> "Forum / Post"
       def friendly_name
         model_name.split("::").map { |part| part.underscore.humanize }.join(" / ").titlecase
       end

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -72,7 +72,7 @@ module Madmin
       end
 
       def friendly_name
-        model_name.split("::").map { |part| part.underscore.humanize }.join(" / ").titlecase.pluralize
+        model_name.split("::").map { |part| part.underscore.humanize }.join(" / ").titlecase
       end
 
       # Support for isolated namespaces

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -71,6 +71,8 @@ module Madmin
         )
       end
 
+       # Returns singular name
+       # For example: "Forum::Post" -> "Forum / Post"
       def friendly_name
         model_name.split("::").map { |part| part.underscore.humanize }.join(" / ").titlecase
       end

--- a/test/madmin/resource_test.rb
+++ b/test/madmin/resource_test.rb
@@ -13,7 +13,7 @@ class ResourceTest < ActiveSupport::TestCase
   end
 
   test "friendly_name" do
-    assert_equal "Users", UserResource.friendly_name
-    assert_equal "Foo Bar Bahs", FooBarBahResource.friendly_name
+    assert_equal "User", UserResource.friendly_name
+    assert_equal "Foo Bar Bah", FooBarBahResource.friendly_name
   end
 end


### PR DESCRIPTION
This is a cosmetic 💄 change and removes defaulting a resource's friendly name to plural. This allows us to have "new" buttons with singular resource names.

**Before**: 
<img width="742" height="242" alt="Screenshot 2025-08-15 at 1 25 20 PM" src="https://github.com/user-attachments/assets/2de4c55e-e13e-43ba-a87e-4cc23bab4465" />

**After**: 
<img width="764" height="301" alt="Screenshot 2025-08-15 at 1 23 29 PM" src="https://github.com/user-attachments/assets/3c178cd6-b82b-4fe1-b43e-b3edb37f6ff0" />

**Extra**: 
This also prevents us from calling `pluralize` twice at a few call sites: 
<img width="523" height="397" alt="Screenshot 2025-08-15 at 1 41 35 PM" src="https://github.com/user-attachments/assets/30a19f9e-9bf2-4d01-9146-02cddea2ed79" />
