### PR TITLE
[#296]: Belongs-to field should show all possible records, not just the current one

### DIFF
--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -2,7 +2,7 @@ module Madmin
   module Fields
     class BelongsTo < Field
       def options_for_select(record)
-        records = associated_resource.model.all
+        records = associated_resource.model.limit(25)
         records.map { [Madmin.resource_for(_1).display_name(_1), _1.id] }
       end
 

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -2,7 +2,7 @@ module Madmin
   module Fields
     class BelongsTo < Field
       def options_for_select(record)
-        [record.send(attribute_name)].compact + associated_resource.model.limit(25)
+        records = [record.send(attribute_name)].compact + associated_resource.model.limit(25)
         records.map { [Madmin.resource_for(_1).display_name(_1), _1.id] }
       end
 

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -2,7 +2,7 @@ module Madmin
   module Fields
     class BelongsTo < Field
       def options_for_select(record)
-        records = associated_resource.model.limit(25)
+[record.send(attribute_name)].compact + associated_resource.model.limit(25)
         records.map { [Madmin.resource_for(_1).display_name(_1), _1.id] }
       end
 

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -2,12 +2,7 @@ module Madmin
   module Fields
     class BelongsTo < Field
       def options_for_select(record)
-        records = if (record = record.send(attribute_name))
-          [record]
-        else
-          associated_resource.model.first(25)
-        end
-
+        records = associated_resource.model.all
         records.map { [Madmin.resource_for(_1).display_name(_1), _1.id] }
       end
 

--- a/lib/madmin/fields/belongs_to.rb
+++ b/lib/madmin/fields/belongs_to.rb
@@ -2,7 +2,7 @@ module Madmin
   module Fields
     class BelongsTo < Field
       def options_for_select(record)
-[record.send(attribute_name)].compact + associated_resource.model.limit(25)
+        [record.send(attribute_name)].compact + associated_resource.model.limit(25)
         records.map { [Madmin.resource_for(_1).display_name(_1), _1.id] }
       end
 


### PR DESCRIPTION
## In this PR: 

- [x] If the associated resource is nil, we show all records in the dropdown. 
- [x] If the associated resource is present, we still show all records, but keep the associated one pre-selected. 

https://github.com/excid3/madmin/issues/296


