### PR TITLE
fix code fence in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ For example, we can use a select for the genre attribute and specify the collect
 class BookResource < Madmin::Resource
   attribute :genre, :select, collection: ["Fiction", "Mystery", "Thriller"]
 end
+```
 
 ## Custom Fields
 


### PR DESCRIPTION
The closing code fence was missing the `BookResource` class, breaking the rendering of subsequent text between that point and the next closing code fence.