### PR TITLE
Fix route namespace singularization for plural module names

### DIFF
--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -84,7 +84,7 @@ module Madmin
         namespace = model.module_parents.detect do |n|
           n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
         end
-        @route_namespace = (namespace ? namespace.name.singularize.underscore.to_sym : nil)
+        @route_namespace = (namespace ? namespace.name.underscore.to_sym : nil)
       end
 
       def index_path(options = {})


### PR DESCRIPTION
While trying to integrate `madmin` into my project which also uses the [pricing_plans](https://github.com/rameerez/pricing_plans) and [usage_credits](https://github.com/rameerez/usage_credits/) gems, I started getting errors like these on any `madmin` page, none was loading:

```
undefined method 'madmin_usage_credit_wallets_path'
```

I came across all these errors just by following the README instructions, so I thought it could be a bug, which I think it is. Fortunately, it seems like it's just a single line.

The problem was the `.singularize` call in here:
https://github.com/excid3/madmin/blob/5b481d6df036b1c35327e2301a44c0e166b48620/lib/madmin/resource.rb#L87

Which incorrectly transforms plural namespace module names. Both pricing_plans and usage_credits have multiple namespaced models, which get incorrectly converted by `madmin`:
  - PricingPlans → PricingPlan → :pricing_plan (should be :pricing_plans)
  - UsageCredits → UsageCredit → :usage_credit (should be :usage_credits)

This caused undefined method errors like: `undefined method 'madmin_pricing_plan_assignments_path'` (expected: `'madmin_pricing_plans_assignments_path'`)

The bug probably went undetected because Rails' built-in engines work because they're singular: `ActionText`, `ActiveStorage`, `ActionMailbox` don't change when singularized. Also the test suite only tests `ActionText::RichTextResource`, which doesn't expose the bug.

This affects all four path methods (index, new, show, edit) for any namespaced model with a plural namespace name.

After the fix all tests pass, and I also tested it manually in my app while using my other gems and now everything works fine!