### PR TITLE
Support labels in index view

### DIFF
--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -39,7 +39,7 @@
           <% next if attribute.field.nil? %>
           <% next unless attribute.field.visible?(action_name) %>
 
-          <th><%= sortable attribute.name, attribute.name.to_s.titleize %></th>
+          <th><%= sortable attribute.name, attribute.field.label %></th>
         <% end %>
         <th></th>
       </tr>

--- a/app/views/madmin/application/show.html.erb
+++ b/app/views/madmin/application/show.html.erb
@@ -25,7 +25,7 @@
 
       <tr>
         <th class="label">
-          <%= attribute.field.options.label || attribute.name.to_s.titleize %>
+          <%= attribute.field.label %>
         </th>
 
         <td>

--- a/lib/madmin/field.rb
+++ b/lib/madmin/field.rb
@@ -29,6 +29,10 @@ module Madmin
       attribute_name
     end
 
+    def label
+      options[:label].presence || attribute_name.to_s.titleize
+    end
+
     # Used for checking visibility of attribute on an view
     def visible?(action)
       action = action.to_sym

--- a/test/madmin/field_test.rb
+++ b/test/madmin/field_test.rb
@@ -14,4 +14,28 @@ class Madmin::FieldTest < ActiveSupport::TestCase
   test "visible?" do
     assert UserResource.attributes[:name].field.visible?(:index)
   end
+
+  test "label" do
+    assert_equal "First Name", UserResource.attributes[:first_name].field.label
+  end
+
+  test "label with custom option" do
+    field = Madmin::Fields::String.new(
+      attribute_name: :some_attribute,
+      model: User,
+      resource: UserResource,
+      options: ActiveSupport::OrderedOptions.new.merge(label: "Custom Label")
+    )
+    assert_equal "Custom Label", field.label
+  end
+
+  test "label with blank option" do
+    field = Madmin::Fields::String.new(
+      attribute_name: :some_attribute,
+      model: User,
+      resource: UserResource,
+      options: ActiveSupport::OrderedOptions.new.merge(label: "")
+    )
+    assert_equal "Some Attribute", field.label
+  end
 end


### PR DESCRIPTION
Hi @excid3, thanks for the great gem! First time using it over administrate. 

This PR makes the index view use the same `label` override as the show page for consistency. WDYT? 

