### PR TITLE
Add collection_action DSL — index-page counterpart to member_action

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,40 @@ class PostResource < Madmin::Resource
 end
 ```
 
+## Actions
+
+### Member Actions
+
+`member_action` lets you add custom buttons to a resource's **show** page. Each block receives the current `record` and is rendered in the header's `.actions` div:
+
+```ruby
+class PostResource < Madmin::Resource
+  member_action do |record|
+    link_to "Publish", publish_admin_post_path(record), class: "btn btn-secondary"
+  end
+end
+```
+
+### Collection Actions
+
+`collection_action` is the index-page counterpart to `member_action`. Blocks are rendered in the index header's `.actions` div, immediately before the built-in "New \<Resource\>" link.
+
+Unlike `member_action`, blocks receive **no** arguments. Each block is `instance_exec`-ed on the index view context, so `link_to`, route helpers, `policy`, `current_user`, `params`, `resource`, and `@records` are all available. Multiple blocks render in registration order.
+
+Each block is responsible for its own authorization gating — if a button should be hidden for some users, guard it inside the block.
+
+```ruby
+class PostResource < Madmin::Resource
+  collection_action do
+    link_to "Bulk Import", bulk_import_admin_posts_path, class: "btn btn-secondary"
+  end
+
+  collection_action do
+    link_to "Export CSV", export_admin_posts_path(format: :csv), class: "btn btn-secondary"
+  end
+end
+```
+
 ## Authentication
 
 You can use a couple of strategies to authenticate users who are trying to

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -15,6 +15,10 @@
       </svg>
       <% end if params[:q].present? %>
 
+    <% resource.collection_actions.each do |action| %>
+      <%= instance_exec(&action) %>
+    <% end %>
+
     <%= link_to resource.new_path, class: "btn btn-secondary" do %>
       New <%= tag.span resource.friendly_name, class: "hidden md:inline-block" %>
     <% end %>

--- a/lib/generators/madmin/resource/templates/resource.rb.tt
+++ b/lib/generators/madmin/resource/templates/resource.rb.tt
@@ -17,6 +17,11 @@ class <%= class_name %>Resource < Madmin::Resource
   #   link_to "Do Something", some_path
   # end
 
+  # Add actions to the resource's index page
+  # collection_action do
+  #   link_to "Bulk Import", bulk_import_path, class: "btn btn-secondary"
+  # end
+
   # Customize the display name of records in the admin area.
   # def self.display_name(record) = record.name
 

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -4,6 +4,7 @@ module Madmin
 
     class_attribute :attributes, default: ActiveSupport::OrderedHash.new
     class_attribute :member_actions, default: []
+    class_attribute :collection_actions, default: []
     class_attribute :scopes, default: []
     class_attribute :menu_options, instance_reader: false
 
@@ -11,6 +12,7 @@ module Madmin
       def inherited(base)
         base.attributes = attributes.dup
         base.member_actions = scopes.dup
+        base.collection_actions = collection_actions.dup
         base.scopes = scopes.dup
         super
       end
@@ -134,6 +136,10 @@ module Madmin
 
       def member_action(&block)
         member_actions << block
+      end
+
+      def collection_action(&block)
+        collection_actions << block
       end
 
       def field_for_type(type)

--- a/test/dummy/app/madmin/resources/post_resource.rb
+++ b/test/dummy/app/madmin/resources/post_resource.rb
@@ -39,6 +39,10 @@ class PostResource < Madmin::Resource
     end
   end
 
+  collection_action do
+    link_to "Export CSV", main_app.madmin_posts_path(format: :csv), class: "btn btn-secondary"
+  end
+
   # Uncomment this to customize the display name of records in the admin area.
   # def self.display_name(record)
   #   record.name

--- a/test/integration/posts_resource_test.rb
+++ b/test/integration/posts_resource_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class PostsResourceTest < ActionDispatch::IntegrationTest
+  test "index renders collection_action blocks" do
+    get madmin_posts_path
+    assert_response :success
+    assert_select "a[href=?]", madmin_posts_path(format: :csv), text: "Export CSV"
+  end
+
+  test "collection_action blocks render before the New link" do
+    get madmin_posts_path
+    assert_response :success
+
+    # Both the collection action link and the New link should be present in the actions div
+    assert_select ".actions" do
+      assert_select "a", text: "Export CSV"
+      assert_select "a", text: /New/
+    end
+  end
+end

--- a/test/madmin/resource_test.rb
+++ b/test/madmin/resource_test.rb
@@ -2,6 +2,14 @@ require "test_helper"
 
 class FooBarBahResource < Madmin::Resource; end
 
+class CollectionActionParentResource < Madmin::Resource
+  collection_action { "parent_action" }
+end
+
+class CollectionActionChildResource < CollectionActionParentResource
+  collection_action { "child_action" }
+end
+
 class ResourceTest < ActiveSupport::TestCase
   test "searchable_attributes" do
     searchable_attribute_names = UserResource.searchable_attributes.map(&:name)
@@ -15,5 +23,24 @@ class ResourceTest < ActiveSupport::TestCase
   test "friendly_name" do
     assert_equal "User", UserResource.friendly_name
     assert_equal "Foo Bar Bah", FooBarBahResource.friendly_name
+  end
+
+  test "collection_actions defaults to empty array" do
+    assert_equal [], Madmin::Resource.collection_actions
+  end
+
+  test "collection_action appends block to collection_actions" do
+    assert_equal 1, CollectionActionParentResource.collection_actions.size
+    assert_equal "parent_action", CollectionActionParentResource.collection_actions.first.call
+  end
+
+  test "subclass inherits parent collection_actions and can add its own" do
+    assert_equal 2, CollectionActionChildResource.collection_actions.size
+    assert_equal "parent_action", CollectionActionChildResource.collection_actions.first.call
+    assert_equal "child_action", CollectionActionChildResource.collection_actions.last.call
+  end
+
+  test "child collection_actions do not leak to parent" do
+    assert_equal 1, CollectionActionParentResource.collection_actions.size
   end
 end


### PR DESCRIPTION
**Add `collection_action` DSL — index-page counterpart to `member_action`**

Madmin already supports custom action buttons on the show page via `member_action`. There is no symmetric hook for the index page, so adding e.g. a "Bulk Import" or "Export CSV" button currently requires cloning the entire `index.html.erb` template into the host app, which makes Madmin upgrades painful.

This PR introduces `collection_action`, a one-liner DSL that mirrors `member_action`:

```ruby
class PostResource < Madmin::Resource
  collection_action do
    link_to "Bulk Import", bulk_import_admin_posts_path, class: "btn btn-secondary"
  end
end
```

Blocks render in the index header's `.actions` div, immediately before the built-in "New <Resource>" link, `instance_exec`-ed on the view context so route helpers, `policy`, `current_user`, `params`, `resource`, and `@records` are all available. Multiple blocks render in registration order. Authorization gating is the block's responsibility (mirroring `member_action`).

No behavior changes for resources that don't register any `collection_action` blocks.