### PR TITLE
Fix `new:` and `edit:` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* Fix `new:` and `edit:` options setting. Fixes #332
+
 ### 2.3.2
 
 - Support plural module names #313

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -5,3 +5,17 @@ Madmin uses Resource classes to add models to the admin area.
 To generate a resource for a model, you can run:
 
 rails g madmin:resource ActionText::RichText
+
+## Attribute Options
+
+Each attribute supports visibility options to control where it appears:
+
+| Option        | Description                            |
+|---------------|----------------------------------------|
+| `index`       | Show on the index (list) page          |
+| `show`        | Show on the show (detail) page         |
+| `form`        | Show on both new and edit forms        |
+| `new`         | Show on the new form                   |
+| `edit`        | Show on the edit form                  |
+| `label`       | Custom label for the attribute         |
+| `description` | Help text displayed with the attribute |

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -54,10 +54,16 @@ module Madmin
         config = ActiveSupport::OrderedOptions.new.merge(options)
         yield config if block_given?
 
-        # Form is an alias for new & edit but shouldn't override their values if explicitly set
+        # Form is an alias for new & edit but shouldn't override their values if explicitly set (true/false)
+        config.new = config[:form] if config[:new].nil?
+        config.edit = config[:form] if config[:edit].nil?
+
         # New/create and edit/update need to match
-        config.new = config.create = config[:form] || config[:new]
-        config.edit = config.update = config[:form] || config[:edit]
+        config.create = config.new
+        config.update = config.edit
+
+        # Remove any nil values to use the defaults
+        config.compact!
 
         attributes[name] = Attribute.new(
           name: name,

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -54,15 +54,10 @@ module Madmin
         config = ActiveSupport::OrderedOptions.new.merge(options)
         yield config if block_given?
 
-        # Form is an alias for new & edit
-        if config.has_key?(:form)
-          config.new = config[:form]
-          config.edit = config[:form]
-        end
-
+        # Form is an alias for new & edit but shouldn't override their values if explicitly set
         # New/create and edit/update need to match
-        config.create = config[:create] if config.has_key?(:new)
-        config.update = config[:update] if config.has_key?(:edit)
+        config.new = config.create = config[:form] || config[:new]
+        config.edit = config.update = config[:form] || config[:edit]
 
         attributes[name] = Attribute.new(
           name: name,

--- a/test/dummy/app/madmin/resources/event_resource.rb
+++ b/test/dummy/app/madmin/resources/event_resource.rb
@@ -1,7 +1,7 @@
 class EventResource < Madmin::Resource
   # Attributes
   attribute :id, form: false
-  attribute :type
+  attribute :type, form: true
   attribute :created_at, form: false
   attribute :updated_at, form: false
 

--- a/test/dummy/app/madmin/resources/user_resource.rb
+++ b/test/dummy/app/madmin/resources/user_resource.rb
@@ -1,7 +1,7 @@
 class UserResource < Madmin::Resource
   # Attributes
   attribute :id, form: false
-  attribute :name, :string, form: :false
+  attribute :name, :string, form: false
   attribute :first_name
   attribute :last_name
   attribute :birthday


### PR DESCRIPTION
Ensures that `new` and `edit` override `form` correctly, including handling `false`.

```
form: false, new: true #=> Displays on new / create, hidden on edit / update
form: false, edit: true #=> Displays on edit / update, hidden on new / create
form: true, new: false #=> Displays on edit / update, hidden on new / create
form: true, edit: false #=> Displays on new / create, hidden on edit/update
form: nil, new: true #=> Displays on new / create, uses default for edit / update
form: nil, edit: true #=> Displays on edit / update, uses default for new / create
```

Ensures that `create` and `update` always match `new` and `update` respectively.

Closes #332

cc @anthony0030 