### PR TITLE
Add Korean (ko) locale for Madmin UI strings

### DIFF
--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,0 +1,40 @@
+ko:
+  madmin:
+    layout:
+      open_menu: 메뉴 열기
+      admin_suffix: 관리자
+    navigation:
+      dashboard: 대시보드
+      github: GitHub에서 Madmin 보기
+    dashboard:
+      title: Madmin 대시보드
+      hint_html: 대시보드를 원하는 대로 꾸미려면 <code>app/views/madmin/dashboard/show.html.erb</code> 파일을 생성하세요.
+    actions:
+      all: 전체
+      view: 보기
+      edit: 수정
+      delete: 삭제
+      new: 새로 만들기
+      remove: 제거
+      cancel: 취소
+    search:
+      placeholder: 검색
+    titles:
+      new: 새 %{name}
+      edit: "%{name} 수정"
+    form:
+      errors:
+        one: 제출한 내용에 오류가 1개 있습니다
+        other: 제출한 내용에 오류가 %{count}개 있습니다
+    confirmations:
+      delete: 정말 삭제하시겠습니까?
+      remove_with_changes: 정말 삭제하시겠습니까? 다른 변경 사항도 함께 사라집니다.
+    nested_form:
+      add_new: "+ 새로 추가"
+    fields:
+      attachment:
+        one: "첨부파일 %{count}개"
+        other: "첨부파일 %{count}개"
+    missing_resource:
+      message: "%{resource}이(가) 존재하지 않습니다."
+      create_hint: "다음 명령어를 실행하여 생성하세요:"

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -28,7 +28,7 @@ ko:
         other: 제출한 내용에 오류가 %{count}개 있습니다
     confirmations:
       delete: 정말 삭제하시겠습니까?
-      remove_with_changes: 정말 삭제하시겠습니까? 다른 변경 사항도 함께 사라집니다.
+      remove_with_changes: 정말 제거하시겠습니까? 다른 변경 사항도 함께 사라집니다.
     nested_form:
       add_new: "+ 새로 추가"
     fields:


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.

한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.

## Changes

- Added `config/locales/ko.yml` with a full Korean translation of all 25 keys in `config/locales/en.yml` (the source of truth), following the same structure already used by the existing `config/locales/fr.yml`.
- No code changes needed: Madmin's engine (`lib/madmin/engine.rb`) relies on Rails::Engine's default `config/locales/**/*.yml` autoload path, the same mechanism that already loads `fr.yml` with zero extra registration — confirmed there are no other references to `fr.yml`/`ko.yml` anywhere in the codebase.

## Testing

- Verified 25/25 key parity between `en.yml` and `ko.yml` (no missing or extra keys) using Ruby's own `YAML`/Psych parser (the same library Rails uses to load locale files).
- Verified every `%{...}` interpolation token (`%{name}`, `%{count}`, `%{resource}`) matches exactly between the English and Korean strings.
- Verified `dashboard.hint_html`'s `<code>app/views/madmin/dashboard/show.html.erb</code>` tag is preserved byte-for-byte in the Korean string.
- Read every call site of the translated keys (e.g. `app/views/madmin/application/show.html.erb`, `app/views/madmin/fields/attachment/_form.html.erb`) to check translations match their actual UI context, and fixed one inconsistency found this way: `confirmations.remove_with_changes` (shown on the attachment "제거"/Remove link) previously used the delete-specific wording "삭제하시겠습니까?"; changed to "제거하시겠습니까?" so the confirm dialog's verb matches the button it belongs to.
- Could not run `bundle install` / the Rails test suite in this environment (gem/native-extension build errors unrelated to the translation, e.g. `mysql2` native extension build failure); this does not affect a locale-only YAML addition.
