### PR TITLE
Fix Madmin importmap assets with Propshaft

### DIFF
--- a/lib/madmin.rb
+++ b/lib/madmin.rb
@@ -1,9 +1,9 @@
-require "madmin/engine"
-
+require "propshaft"
 require "importmap-rails"
 require "stimulus-rails"
 require "turbo-rails"
 require "pagy"
+require "madmin/engine"
 
 module Madmin
   autoload :Field, "madmin/field"

--- a/test/integration/assets_test.rb
+++ b/test/integration/assets_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class AssetsTest < ActionDispatch::IntegrationTest
+  test "madmin renders resolved asset urls" do
+    get madmin_root_path
+
+    assert_response :success
+    assert_match %r{"application": "/assets/[^"]+\.js"}, response.body
+    assert_match %r{"@hotwired/turbo-rails": "/assets/[^"]+\.js"}, response.body
+  end
+end


### PR DESCRIPTION
I hope this wasn't just an issue on my machine, but I ran into broken local asset URLs in the dummy app and traced it back to Propshaft not being loaded before the engine booted.

## Summary
- require `propshaft` before booting the engine so importmap asset paths resolve correctly
- restore Madmin's JavaScript and stylesheet asset loading in the dummy app
- add an integration test covering resolved asset URLs on `/madmin`

## Problem
The dummy app rendered importmap tags, but local asset URLs were unresolved and fell back to broken paths like:

- `/madmin/application.js`
- `/turbo.min.js`
- `/stylesheets/dummy.css`

That left Madmin with missing JavaScript and CSS in development.

## Fix
Load `propshaft` before `madmin/engine` so the asset server is available when importmap and stylesheet helpers resolve Madmin assets.