### PR TITLE
Add read-only resource support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ end
 
 ```
 
+### Read-only Resources
+
+To expose a resource in the admin without allowing writes, override `readonly?` in the resource:
+
+```ruby
+class AuditLogResource < Madmin::Resource
+  def self.readonly?
+    true
+  end
+end
+```
+
+The new, edit, and delete links are hidden for read-only resources, and any write actions redirect back to the index.
+
 ## Configuring Views
 
 The views packaged within the gem are a great starting point, but inevitably people will need to be able to customize those views.

--- a/app/controllers/madmin/resource_controller.rb
+++ b/app/controllers/madmin/resource_controller.rb
@@ -3,6 +3,7 @@ module Madmin
     include SortHelper
 
     before_action :set_record, except: [:index, :new, :create]
+    before_action :enforce_readonly, only: [:new, :create, :edit, :update, :destroy]
 
     # Assign current_user for paper_trail gem
     before_action :set_paper_trail_whodunnit, if: -> { respond_to?(:set_paper_trail_whodunnit, true) }
@@ -100,6 +101,10 @@ module Madmin
 
     def search_term
       @search_term ||= params[:q].to_s.strip
+    end
+
+    def enforce_readonly
+      redirect_to resource.index_path, alert: t("madmin.flash.readonly", name: resource.friendly_name) if resource.readonly?
     end
 
     ActiveSupport.run_load_hooks(:madmin_resource_controller, self)

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -19,8 +19,10 @@
       <%= instance_exec(&action) %>
     <% end %>
 
-    <%= link_to resource.new_path, class: "btn btn-secondary" do %>
-      <%= t("madmin.actions.new") %> <%= tag.span resource.friendly_name, class: "hidden md:inline-block" %>
+    <% unless resource.readonly? %>
+      <%= link_to resource.new_path, class: "btn btn-secondary" do %>
+        <%= t("madmin.actions.new") %> <%= tag.span resource.friendly_name, class: "hidden md:inline-block" %>
+      <% end %>
     <% end %>
   </div>
 </header>
@@ -60,7 +62,7 @@
 
           <td class="actions">
             <%= link_to t("madmin.actions.view"), resource.show_path(record), class: "btn btn-secondary" %>
-            <%= link_to t("madmin.actions.edit"), resource.edit_path(record), class: "btn btn-secondary" %>
+            <%= link_to t("madmin.actions.edit"), resource.edit_path(record), class: "btn btn-secondary" unless resource.readonly? %>
 
             <% resource.collection_member_actions.each do |action| %>
               <%= instance_exec(record, &action) %>

--- a/app/views/madmin/application/show.html.erb
+++ b/app/views/madmin/application/show.html.erb
@@ -11,8 +11,10 @@
     <% resource.member_actions.each do |action| %>
       <%= instance_exec(@record, &action) %>
     <% end %>
-    <%= link_to t("madmin.actions.edit"), resource.edit_path(@record), class: "btn btn-secondary" %>
-    <%= button_to t("madmin.actions.delete"), resource.show_path(@record), method: :delete, data: { turbo_confirm: t("madmin.confirmations.delete") }, class: "btn btn-danger" %>
+    <% unless resource.readonly? %>
+      <%= link_to t("madmin.actions.edit"), resource.edit_path(@record), class: "btn btn-secondary" %>
+      <%= button_to t("madmin.actions.delete"), resource.show_path(@record), method: :delete, data: { turbo_confirm: t("madmin.confirmations.delete") }, class: "btn btn-danger" %>
+    <% end %>
   </div>
 </header>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,8 @@ en:
       errors:
         one: There was 1 error with your submission
         other: There were %{count} errors with your submission
+    flash:
+      readonly: "%{name} is read-only"
     confirmations:
       delete: Are you sure?
       remove_with_changes: Are you sure? You will lose any other changes.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -26,6 +26,8 @@ fr:
       errors:
         one: Il y a eu 1 erreur dans votre soumission
         other: Il y a eu %{count} erreurs dans votre soumission
+    flash:
+      readonly: "%{name} est en lecture seule"
     confirmations:
       delete: Êtes-vous sûr ?
       remove_with_changes: Êtes-vous sûr ? Vous perdrez toutes les autres modifications.

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -126,6 +126,10 @@ module Madmin
         model.respond_to? :friendly
       end
 
+      def readonly?
+        false
+      end
+
       def sortable_columns
         model.column_names
       end

--- a/test/integration/readonly_resource_test.rb
+++ b/test/integration/readonly_resource_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class ReadonlyResourceTest < ActionDispatch::IntegrationTest
+  test "resources are writable by default" do
+    assert_not PostResource.readonly?
+  end
+
+  test "index hides new and edit links for readonly resources" do
+    with_readonly(PostResource) do
+      get madmin_posts_path
+      assert_response :success
+      assert_select "a[href=?]", new_madmin_post_path, count: 0
+      assert_select "a[href=?]", edit_madmin_post_path(posts(:one)), count: 0
+    end
+  end
+
+  test "show hides edit and delete buttons for readonly resources" do
+    with_readonly(PostResource) do
+      get madmin_post_path(posts(:one))
+      assert_response :success
+      assert_select "a[href=?]", edit_madmin_post_path(posts(:one)), count: 0
+      assert_select "form[action=?]", madmin_post_path(posts(:one)), count: 0
+    end
+  end
+
+  test "new and create redirect for readonly resources" do
+    with_readonly(PostResource) do
+      get new_madmin_post_path
+      assert_redirected_to madmin_posts_path
+      assert_equal "Post is read-only", flash[:alert]
+
+      assert_no_difference "Post.count" do
+        post madmin_posts_path, params: {post: {title: "Nope"}}
+      end
+      assert_redirected_to madmin_posts_path
+    end
+  end
+
+  test "edit, update and destroy redirect for readonly resources" do
+    with_readonly(PostResource) do
+      get edit_madmin_post_path(posts(:one))
+      assert_redirected_to madmin_posts_path
+
+      put madmin_post_path(posts(:one)), params: {post: {title: "Nope"}}
+      assert_redirected_to madmin_posts_path
+      assert_not_equal "Nope", posts(:one).reload.title
+
+      assert_no_difference "Post.count" do
+        delete madmin_post_path(posts(:one))
+      end
+      assert_redirected_to madmin_posts_path
+    end
+  end
+
+  private
+
+  def with_readonly(resource_class)
+    resource_class.singleton_class.define_method(:readonly?) { true }
+    yield
+  ensure
+    resource_class.singleton_class.remove_method(:readonly?)
+  end
+end


### PR DESCRIPTION
Thanks for splitting out the load hooks in #350 — this PR is now rebased on top of that and slimmed down to a single feature: read-only resources. The remaining extension seams from the original diff are split into their own follow-up PR.

Resources can opt out of writes by overriding `readonly?` (default `false`):

```ruby
class AuditLogResource < Madmin::Resource
  def self.readonly?
    true
  end
end
```

- Write actions (`new`/`create`/`edit`/`update`/`destroy`) redirect back to the index with an i18n'd alert (en + fr locale keys included)
- The New, Edit, and Delete links are hidden in the index and show views
- Integration tests cover both the UI and the controller enforcement; README documents the feature

Useful on its own for audit-log-style resources, and it's the piece a gem extension can't add from the outside, since views can't be patched via the load hooks.