### PR TITLE
Add collection: option to member_action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+* Add `collection: true` option to `member_action` to also render the action in each row on the index page
+* Fix `member_actions` being overwritten with `scopes` on subclassed resources
+
 ### 2.4.0
 
 * Add `collection_action` for resources

--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ class PostResource < Madmin::Resource
 end
 ```
 
+Pass `collection: true` to also render the action on the **index** page, in each row next to the built-in "View" and "Edit" links:
+
+```ruby
+class PostResource < Madmin::Resource
+  member_action collection: true do |record|
+    link_to "Publish", publish_admin_post_path(record), class: "btn btn-secondary"
+  end
+end
+```
+
 ### Collection Actions
 
 `collection_action` is the index-page counterpart to `member_action`. Blocks are rendered in the index header's `.actions` div, immediately before the built-in "New \<Resource\>" link.

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -61,6 +61,10 @@
           <td>
             <%= link_to t("madmin.actions.view"), resource.show_path(record) %>
             <%= link_to t("madmin.actions.edit"), resource.edit_path(record) %>
+
+            <% resource.collection_member_actions.each do |action| %>
+              <%= instance_exec(record, &action) %>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/lib/generators/madmin/resource/templates/resource.rb.tt
+++ b/lib/generators/madmin/resource/templates/resource.rb.tt
@@ -13,6 +13,7 @@ class <%= class_name %>Resource < Madmin::Resource
   # scope :published
 
   # Add actions to the resource's show page
+  # Pass collection: true to also render it in each row on the index page
   # member_action do |record|
   #   link_to "Do Something", some_path
   # end

--- a/lib/madmin.rb
+++ b/lib/madmin.rb
@@ -5,6 +5,7 @@ require "turbo-rails"
 require "pagy"
 
 module Madmin
+  autoload :Action, "madmin/action"
   autoload :Field, "madmin/field"
   autoload :GeneratorHelpers, "madmin/generator_helpers"
   autoload :Menu, "madmin/menu"

--- a/lib/madmin.rb
+++ b/lib/madmin.rb
@@ -5,9 +5,9 @@ require "turbo-rails"
 require "pagy"
 
 module Madmin
-  autoload :Action, "madmin/action"
   autoload :Field, "madmin/field"
   autoload :GeneratorHelpers, "madmin/generator_helpers"
+  autoload :MemberAction, "madmin/member_action"
   autoload :Menu, "madmin/menu"
   autoload :Resource, "madmin/resource"
   autoload :ResourceBuilder, "madmin/resource_builder"

--- a/lib/madmin/action.rb
+++ b/lib/madmin/action.rb
@@ -1,0 +1,25 @@
+module Madmin
+  # Wraps a member/collection action block along with its options so views can
+  # decide where to render it. Responds to `to_proc` and `call` so it can be
+  # used anywhere the raw block was.
+  class Action
+    attr_reader :block
+
+    def initialize(collection: false, &block)
+      @collection = collection
+      @block = block
+    end
+
+    def collection?
+      @collection
+    end
+
+    def call(*args, &blk)
+      block.call(*args, &blk)
+    end
+
+    def to_proc
+      block
+    end
+  end
+end

--- a/lib/madmin/member_action.rb
+++ b/lib/madmin/member_action.rb
@@ -1,8 +1,8 @@
 module Madmin
-  # Wraps a member/collection action block along with its options so views can
-  # decide where to render it. Responds to `to_proc` and `call` so it can be
-  # used anywhere the raw block was.
-  class Action
+  # Wraps a member action block along with its options so views can decide
+  # where to render it. Responds to `to_proc` and `call` so it can be used
+  # anywhere the raw block was.
+  class MemberAction
     attr_reader :block
 
     def initialize(collection: false, &block)

--- a/lib/madmin/member_action.rb
+++ b/lib/madmin/member_action.rb
@@ -10,16 +10,10 @@ module Madmin
       @block = block
     end
 
-    def collection?
-      @collection
-    end
+    def collection? = @collection
 
-    def call(*args, &blk)
-      block.call(*args, &blk)
-    end
+    def call(*args, &blk) = block.call(*args, &blk)
 
-    def to_proc
-      block
-    end
+    def to_proc = block
   end
 end

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -11,7 +11,7 @@ module Madmin
     class << self
       def inherited(base)
         base.attributes = attributes.dup
-        base.member_actions = scopes.dup
+        base.member_actions = member_actions.dup
         base.collection_actions = collection_actions.dup
         base.scopes = scopes.dup
         super
@@ -134,8 +134,13 @@ module Madmin
         attributes.values.select { |a| a.field.searchable? }
       end
 
-      def member_action(&block)
-        member_actions << block
+      def member_action(collection: false, &block)
+        member_actions << Action.new(collection: collection, &block)
+      end
+
+      # Member actions that should also render in each row on the index page
+      def collection_member_actions
+        member_actions.select { |action| action.respond_to?(:collection?) && action.collection? }
       end
 
       def collection_action(&block)

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -135,7 +135,7 @@ module Madmin
       end
 
       def member_action(collection: false, &block)
-        member_actions << Action.new(collection: collection, &block)
+        member_actions << MemberAction.new(collection: collection, &block)
       end
 
       # Member actions that should also render in each row on the index page

--- a/test/dummy/app/madmin/resources/post_resource.rb
+++ b/test/dummy/app/madmin/resources/post_resource.rb
@@ -39,6 +39,11 @@ class PostResource < Madmin::Resource
     end
   end
 
+  # Rendered on the show page and in each row on the index page
+  member_action collection: true do |record|
+    link_to "Preview", main_app.madmin_post_path(record), class: "btn btn-secondary"
+  end
+
   collection_action do
     link_to "Export CSV", main_app.madmin_posts_path(format: :csv), class: "btn btn-secondary"
   end

--- a/test/integration/posts_resource_test.rb
+++ b/test/integration/posts_resource_test.rb
@@ -17,4 +17,31 @@ class PostsResourceTest < ActionDispatch::IntegrationTest
       assert_select "a", text: /New/
     end
   end
+
+  test "index renders member actions with collection: true alongside the view and edit links" do
+    get madmin_posts_path
+    assert_response :success
+
+    assert_select "tbody tr td:last-child" do
+      assert_select "a", text: "View"
+      assert_select "a", text: "Edit"
+      assert_select "a", text: "Preview"
+    end
+  end
+
+  test "index does not render member actions without collection: true" do
+    get madmin_posts_path
+    assert_response :success
+
+    assert_select "tbody form", text: /Publish/, count: 0
+  end
+
+  test "show renders all member actions" do
+    get madmin_post_path(posts(:one))
+    assert_response :success
+
+    assert_select ".actions" do
+      assert_select "a", text: "Preview"
+    end
+  end
 end

--- a/test/madmin/resource_test.rb
+++ b/test/madmin/resource_test.rb
@@ -10,6 +10,15 @@ class CollectionActionChildResource < CollectionActionParentResource
   collection_action { "child_action" }
 end
 
+class MemberActionParentResource < Madmin::Resource
+  member_action { "parent_action" }
+  member_action(collection: true) { "parent_collection_action" }
+end
+
+class MemberActionChildResource < MemberActionParentResource
+  member_action { "child_action" }
+end
+
 class ResourceTest < ActiveSupport::TestCase
   test "searchable_attributes" do
     searchable_attribute_names = UserResource.searchable_attributes.map(&:name)
@@ -42,5 +51,32 @@ class ResourceTest < ActiveSupport::TestCase
 
   test "child collection_actions do not leak to parent" do
     assert_equal 1, CollectionActionParentResource.collection_actions.size
+  end
+
+  test "member_actions defaults to empty array" do
+    assert_equal [], Madmin::Resource.member_actions
+  end
+
+  test "member_action defaults to collection: false" do
+    action = MemberActionParentResource.member_actions.first
+    refute_predicate action, :collection?
+    assert_equal "parent_action", action.call
+  end
+
+  test "collection_member_actions only includes actions with collection: true" do
+    actions = MemberActionParentResource.collection_member_actions
+    assert_equal 1, actions.size
+    assert_equal "parent_collection_action", actions.first.call
+  end
+
+  test "member actions can be converted to a block" do
+    assert_equal "parent_action", instance_exec(&MemberActionParentResource.member_actions.first)
+  end
+
+  test "subclass inherits parent member_actions and can add its own" do
+    assert_equal 3, MemberActionChildResource.member_actions.size
+    assert_equal 2, MemberActionParentResource.member_actions.size
+    assert_equal "child_action", MemberActionChildResource.member_actions.last.call
+    assert_equal 1, MemberActionChildResource.collection_member_actions.size
   end
 end


### PR DESCRIPTION
`member_action collection: true` renders the action in each row on the index page, next to the built-in View and Edit links, in addition to the show page. Defaults to `false`, so existing member actions render only on the show page as before.

```ruby
class PostResource < Madmin::Resource
  member_action collection: true do |record|
    link_to "Publish", publish_admin_post_path(record), class: "btn btn-secondary"
  end
end
```

### Implementation

Member actions are now wrapped in a `Madmin::MemberAction` object that carries the block plus its options. It implements `to_proc` and `call`, so iterating `resource.member_actions` and `instance_exec(record, &action)` continue to work unchanged — including in any views an app has already copied out with `rails g madmin:views`.

Index rows have no `@record`, so blocks used with `collection: true` need to use the yielded `record` argument.

### Drive-by fix

`inherited` was doing `base.member_actions = scopes.dup`, so a subclassed resource got its parent's *scopes* as its member actions instead of inheriting the member actions. Invisible for resources inheriting directly from `Madmin::Resource` (both arrays are empty), but broken for any resource subclassing another resource.

### Tests

Unit tests for the option, `collection_member_actions` filtering, block conversion, and inheritance; integration tests asserting the action renders on the index row and that non-collection actions do not. Full suite passes (55 runs, 116 assertions) and standardrb is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
