### PR TITLE
Add ActiveSupport load hooks to Madmin's core classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add `collection: true` option to `member_action` to also render the action in each row on the index page
 * Fix `member_actions` being overwritten with `scopes` on subclassed resources
+* Add `ActiveSupport` load hooks for extending Madmin: `:madmin_resource`, `:madmin_field`, `:madmin_search`, `:madmin_base_controller`, and `:madmin_resource_controller`
 
 ### 2.4.0
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,35 @@ class PostResource < Madmin::Resource
 end
 ```
 
+## Extending Madmin
+
+Madmin runs `ActiveSupport` load hooks on its core classes so you can extend them from an initializer without reopening or monkey patching them. This is the recommended way for engines and gems to add behavior to Madmin.
+
+| Hook | Base | Use it for |
+| --- | --- | --- |
+| `:madmin_resource` | `Madmin::Resource` | Adding to the resource DSL |
+| `:madmin_field` | `Madmin::Field` | Shared behavior across every field type |
+| `:madmin_search` | `Madmin::Search` | Customizing how the search query is built |
+| `:madmin_base_controller` | `Madmin::BaseController` | Layouts, helpers, `rescue_from`, authentication |
+| `:madmin_resource_controller` | `Madmin::ResourceController` | CRUD callbacks, scoping records, audit logging |
+
+Blocks are `class_eval`-ed on the base class, so `self` is the class itself:
+
+```ruby
+# config/initializers/madmin.rb
+ActiveSupport.on_load(:madmin_resource) do
+  # self == Madmin::Resource, so `extend` adds class-level DSL to every resource
+  extend MyAdmin::ResourceExtensions
+end
+
+ActiveSupport.on_load(:madmin_base_controller) do
+  # self == Madmin::BaseController
+  rescue_from Pundit::NotAuthorizedError, with: :admin_not_authorized
+end
+```
+
+Hooks registered after a class has already loaded run immediately, so ordering in your initializers doesn't matter. The controllers live in the engine's `app/` directory and are reloadable, which means their hooks re-run on every reload in development — keep the blocks idempotent.
+
 ## Authentication
 
 You can use a couple of strategies to authenticate users who are trying to

--- a/app/controllers/madmin/base_controller.rb
+++ b/app/controllers/madmin/base_controller.rb
@@ -9,5 +9,7 @@ module Madmin
     end
 
     protect_from_forgery with: :exception
+
+    ActiveSupport.run_load_hooks(:madmin_base_controller, self)
   end
 end

--- a/app/controllers/madmin/resource_controller.rb
+++ b/app/controllers/madmin/resource_controller.rb
@@ -101,5 +101,7 @@ module Madmin
     def search_term
       @search_term ||= params[:q].to_s.strip
     end
+
+    ActiveSupport.run_load_hooks(:madmin_resource_controller, self)
   end
 end

--- a/lib/madmin/field.rb
+++ b/lib/madmin/field.rb
@@ -61,5 +61,7 @@ module Madmin
     def paginateable?
       false
     end
+
+    ActiveSupport.run_load_hooks(:madmin_field, self)
   end
 end

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -272,5 +272,7 @@ module Madmin
         @menu_options.with_defaults(label: friendly_name.pluralize, url: index_path)
       end
     end
+
+    ActiveSupport.run_load_hooks(:madmin_resource, self)
   end
 end

--- a/lib/madmin/search.rb
+++ b/lib/madmin/search.rb
@@ -56,5 +56,7 @@ module Madmin
     def column_to_query(attr)
       ::ActiveRecord::Base.connection.quote_column_name(attr)
     end
+
+    ActiveSupport.run_load_hooks(:madmin_search, self)
   end
 end

--- a/test/madmin/load_hooks_test.rb
+++ b/test/madmin/load_hooks_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+module LoadHookProbe
+  def load_hook_probe
+    "probed"
+  end
+end
+
+class LoadHooksTest < ActiveSupport::TestCase
+  # Hooks registered after the base has already loaded run immediately, so each
+  # test references the constant first to make sure it has been loaded.
+  def assert_load_hook(name, expected)
+    expected.name # force autoload
+    base = nil
+    ActiveSupport.on_load(name) { base = self }
+    assert_equal expected, base, "Expected #{name} load hook to run with #{expected}"
+  end
+
+  test "madmin_resource load hook" do
+    assert_load_hook :madmin_resource, Madmin::Resource
+  end
+
+  test "madmin_field load hook" do
+    assert_load_hook :madmin_field, Madmin::Field
+  end
+
+  test "madmin_search load hook" do
+    assert_load_hook :madmin_search, Madmin::Search
+  end
+
+  test "madmin_base_controller load hook" do
+    assert_load_hook :madmin_base_controller, Madmin::BaseController
+  end
+
+  test "madmin_resource_controller load hook" do
+    assert_load_hook :madmin_resource_controller, Madmin::ResourceController
+  end
+
+  test "load hooks can extend the resource DSL" do
+    refute_respond_to Madmin::Resource, :load_hook_probe
+
+    ActiveSupport.on_load(:madmin_resource) { extend LoadHookProbe }
+
+    assert_equal "probed", Madmin::Resource.load_hook_probe
+    assert_equal "probed", PostResource.load_hook_probe
+  ensure
+    # The hook stays registered, but nothing re-runs :madmin_resource in the
+    # test process, so undefining the method is enough to clean up.
+    Madmin::Resource.singleton_class.undef_method(:load_hook_probe)
+  end
+end


### PR DESCRIPTION
Madmin currently has no extension points — customizing anything the install generator doesn't copy into the app means monkey patching in a `to_prepare` block. This adds `ActiveSupport.run_load_hooks` to the classes that apps and gems most often need to extend.

| Hook | Base | Use it for |
| --- | --- | --- |
| `:madmin_resource` | `Madmin::Resource` | Adding to the resource DSL |
| `:madmin_field` | `Madmin::Field` | Shared behavior across every field type |
| `:madmin_search` | `Madmin::Search` | Customizing how the search query is built |
| `:madmin_base_controller` | `Madmin::BaseController` | Layouts, helpers, `rescue_from`, authentication |
| `:madmin_resource_controller` | `Madmin::ResourceController` | CRUD callbacks, scoping records, audit logging |

```ruby
# config/initializers/madmin.rb
ActiveSupport.on_load(:madmin_resource) do
  extend MyAdmin::ResourceExtensions   # class-level DSL on every resource
end
```

### Notes on the picks

`Madmin::Resource` is the big one — it's the DSL surface every resource inherits, and the natural target for a gem adding `attribute`-style class methods. Ordering works out: initializers run before eager loading, and `Madmin::Resource` is autoloaded the moment the first `app/madmin/resources/*.rb` file references it, so hooks land before any subclass is defined.

`Madmin::BaseController` matters because it's the controller users *don't* own — `Madmin::ApplicationController` gets copied into the app by the install generator, so it's deliberately **not** hooked; people can just edit that file. `Madmin::ResourceController` is subclassed per resource, so a hook is the only way to reach all of them at once.

`Madmin::Field` gives one hook that covers all 23 field subclasses through inheritance.

Left out: `Madmin::Menu` (`before_render` already does this), the `Madmin` module itself (`mattr_accessor` config is settable from an initializer today), and the generator/boot-time internals.

One caveat worth knowing: the two controllers live in the engine's `app/` directory and are reloadable, so their hooks re-run on each reload in development. Blocks need to be idempotent — documented in the README.

### Tests

`test/madmin/load_hooks_test.rb` asserts each hook runs with the right base, plus a functional test that `extend` inside `:madmin_resource` adds a class method visible on a concrete resource. Full suite passes (61 runs, 124 assertions) and standardrb is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)