### PR TITLE
Align index row actions on a single row

### DIFF
--- a/app/assets/stylesheets/madmin/tables.css
+++ b/app/assets/stylesheets/madmin/tables.css
@@ -37,6 +37,12 @@ table {
     a {
       font-weight: 500;
     }
+
+    &.actions {
+      align-items: center;
+      display: flex;
+      gap: 0.5rem;
+    }
   }
 
   tr {

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -58,9 +58,9 @@
             <td><%= render partial: attribute.field.to_partial_path("index"), locals: { field: attribute.field, record: record, resource: resource } %></td>
           <% end %>
 
-          <td>
-            <%= link_to t("madmin.actions.view"), resource.show_path(record) %>
-            <%= link_to t("madmin.actions.edit"), resource.edit_path(record) %>
+          <td class="actions">
+            <%= link_to t("madmin.actions.view"), resource.show_path(record), class: "btn btn-secondary" %>
+            <%= link_to t("madmin.actions.edit"), resource.edit_path(record), class: "btn btn-secondary" %>
 
             <% resource.collection_member_actions.each do |action| %>
               <%= instance_exec(record, &action) %>


### PR DESCRIPTION
On the index table, the view/edit links and collection member actions could wrap onto separate lines.

- Make the actions `<td>` a flex container with centered items and a `0.5rem` gap so view, edit, and any collection member actions sit on the same row.
- Render the view and edit links as `btn btn-secondary` buttons.

Note: the `.actions` class name is reused from the header, but that rule is nested under `.header`, so there's no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)