### PR TITLE
Add extension seams and guards for non-ActiveRecord models

### DIFF
--- a/app/controllers/madmin/resource_controller.rb
+++ b/app/controllers/madmin/resource_controller.rb
@@ -8,7 +8,7 @@ module Madmin
     before_action :set_paper_trail_whodunnit, if: -> { respond_to?(:set_paper_trail_whodunnit, true) }
 
     def index
-      @pagy, @records = pagy(scoped_resources)
+      @pagy, @records = paginate_collection(scoped_resources)
 
       respond_to do |format|
         format.html
@@ -68,7 +68,14 @@ module Madmin
     def scoped_resources
       resources = resource.model.send(valid_scope)
       resources = Madmin::Search.new(resources, resource, search_term).run
+
+      return resources if sort_column.blank?
+
       resources.reorder(sort_column => sort_direction)
+    end
+
+    def paginate_collection(collection)
+      pagy(collection)
     end
 
     def valid_scope

--- a/app/helpers/madmin/sort_helper.rb
+++ b/app/helpers/madmin/sort_helper.rb
@@ -22,7 +22,7 @@ module Madmin
     end
 
     def default_sort_column
-      resource.try(:default_sort_column) || (["created_at", "id", "uuid"] & resource.model.column_names).first
+      resource.try(:default_sort_column) || (["created_at", "id", "uuid"] & resource.sortable_columns).first || resource.sortable_columns.first
     end
 
     def default_sort_direction

--- a/lib/madmin.rb
+++ b/lib/madmin.rb
@@ -78,6 +78,8 @@ module Madmin
     end
 
     def sti_resource_name_for(object)
+      return unless object.class.respond_to?(:inheritance_column) && object.class.respond_to?(:column_names)
+
       if (column = object.class.inheritance_column) && object.class.column_names.include?(column)
         "#{object.class.superclass.base_class.name}Resource"
       end

--- a/lib/madmin/fields/string.rb
+++ b/lib/madmin/fields/string.rb
@@ -2,7 +2,7 @@ module Madmin
   module Fields
     class String < Field
       def searchable?
-        options.fetch(:searchable, model.column_names.include?(attribute_name.to_s))
+        options.fetch(:searchable, resource.model_column_names.include?(attribute_name.to_s))
       end
     end
   end

--- a/lib/madmin/fields/text.rb
+++ b/lib/madmin/fields/text.rb
@@ -2,7 +2,7 @@ module Madmin
   module Fields
     class Text < Field
       def searchable?
-        options.fetch(:searchable, model.column_names.include?(attribute_name.to_s))
+        options.fetch(:searchable, resource.model_column_names.include?(attribute_name.to_s))
       end
     end
   end

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -127,6 +127,10 @@ module Madmin
       end
 
       def sortable_columns
+        model_column_names
+      end
+
+      def model_column_names
         model.column_names
       end
 
@@ -258,6 +262,8 @@ module Madmin
       end
 
       def model_store_accessors
+        return [] unless model.respond_to?(:stored_attributes)
+
         store_accessors = model.stored_attributes.values
         store_accessors.flatten
       end

--- a/lib/madmin/resource_builder.rb
+++ b/lib/madmin/resource_builder.rb
@@ -7,6 +7,8 @@ module Madmin
     end
 
     def associations
+      return [] unless model.respond_to?(:reflections)
+
       model.reflections.reject { |name, association|
         # Hide these special associations
         name.starts_with?("rich_text") ||
@@ -22,10 +24,14 @@ module Madmin
     end
 
     def store_accessors
+      return [] unless model.respond_to?(:stored_attributes)
+
       model.stored_attributes.values.flatten
     end
 
     def virtual_attributes
+      return [] unless model.respond_to?(:attribute_types)
+
       virtual = []
 
       # has_secure_password columns
@@ -50,6 +56,8 @@ module Madmin
     end
 
     def redundant_attributes
+      return [] unless model.respond_to?(:attribute_types)
+
       redundant = []
 
       # has_secure_password columns

--- a/test/madmin/extension_seams_test.rb
+++ b/test/madmin/extension_seams_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class ExtensionSeamsTest < ActiveSupport::TestCase
+  test "model_column_names defaults to the model's column names" do
+    assert_equal Post.column_names, PostResource.model_column_names
+  end
+
+  test "sortable_columns delegates to model_column_names" do
+    resource = Class.new(PostResource) do
+      def self.model_column_names
+        ["id", "title"]
+      end
+    end
+
+    assert_equal ["id", "title"], resource.sortable_columns
+  end
+end


### PR DESCRIPTION
Companion to #348 and the load hooks from #350 — the last piece split out from the original #348 diff. This gives extensions single override points instead of scattered ActiveRecord assumptions, with zero behavior change for regular resources:

- `Resource.model_column_names` (defaults to `model.column_names`), with `sortable_columns`, the sort helper, and the String/Text fields routed through it — one override changes column introspection everywhere
- `paginate_collection` seam in `ResourceController` (default just calls `pagy`)
- Skip `reorder` when there is no sort column
- `respond_to?` guards around `reflections`, `stored_attributes`, `attribute_types`, and `inheritance_column` so model classes without those APIs fail gracefully instead of raising

Together with the load hooks, this is what lets [madmin-static_models](https://github.com/anthony0030/madmin-static_models) support ActiveHash/ActiveYaml models entirely from a gem, as you suggested in #331.