### PR TITLE
Add Greek (el) locale for Madmin UI strings

### DIFF
--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,0 +1,42 @@
+el:
+  madmin:
+    layout:
+      open_menu: Άνοιγμα μενού
+      admin_suffix: Διαχείριση
+    navigation:
+      dashboard: Πίνακας ελέγχου
+      github: Το Madmin στο GitHub
+    dashboard:
+      title: Πίνακας ελέγχου Madmin
+      hint_html: Δημιουργήστε το <code>app/views/madmin/dashboard/show.html.erb</code> για να προσαρμόσετε τον πίνακα ελέγχου σας.
+    actions:
+      all: Όλα
+      view: Προβολή
+      edit: Επεξεργασία
+      delete: Διαγραφή
+      new: Νέο
+      remove: Αφαίρεση
+      cancel: Ακύρωση
+    search:
+      placeholder: Αναζήτηση
+    titles:
+      new: Νέο %{name}
+      edit: Επεξεργασία %{name}
+    form:
+      errors:
+        one: Υπήρξε 1 σφάλμα με την υποβολή σας
+        other: Υπήρξαν %{count} σφάλματα με την υποβολή σας
+    flash:
+      readonly: "%{name}: μόνο για ανάγνωση"
+    confirmations:
+      delete: Είστε σίγουροι;
+      remove_with_changes: Είστε σίγουροι; Θα χάσετε όλες τις άλλες αλλαγές.
+    nested_form:
+      add_new: "+ Προσθήκη νέου"
+    fields:
+      attachment:
+        one: "%{count} συνημμένο"
+        other: "%{count} συνημμένα"
+    missing_resource:
+      message: "Λείπει: %{resource}"
+      create_hint: "Δημιουργήστε το εκτελώντας:"


### PR DESCRIPTION
Thanks for merging my other PRs (#348, #352)!

I saw Korean was added in #342 and realized I'd never thought to add Greek. We use Madmin internally, and if our clients start using it in the future they'll need Greek — so here it is, mirroring the en locale key-for-key (including the new `flash.readonly` string), same shape as #342.

One question while I'm here: do you have a rough idea when the next release will be cut? The gem extension we discussed in #331 ([madmin-static_models](https://github.com/anthony0030/madmin-static_models)) builds on #348/#350/#352, so I'm holding off publishing it to RubyGems until a madmin release includes them.