### PR TITLE
Count association fields on the index with size instead of count

### DIFF
--- a/app/views/madmin/fields/attachments/_index.html.erb
+++ b/app/views/madmin/fields/attachments/_index.html.erb
@@ -1,1 +1,1 @@
-<%= t("madmin.fields.attachment", count: field.value(record).count) %>
+<%= t("madmin.fields.attachment", count: field.value(record).size) %>

--- a/app/views/madmin/fields/has_many/_index.html.erb
+++ b/app/views/madmin/fields/has_many/_index.html.erb
@@ -1,1 +1,1 @@
-<%= pluralize field.value(record).count, field.attribute_name.to_s %>
+<%= pluralize field.value(record).size, field.attribute_name.to_s %>

--- a/app/views/madmin/fields/nested_has_many/_index.html.erb
+++ b/app/views/madmin/fields/nested_has_many/_index.html.erb
@@ -1,1 +1,1 @@
-<%= pluralize field.value(record).count, field.attribute_name.to_s %>
+<%= pluralize field.value(record).size, field.attribute_name.to_s %>


### PR DESCRIPTION
The has_many, nested_has_many, and attachments index partials call `.count` on the association, which always issues a `SELECT COUNT(*)` per row — even when the association was eager-loaded via a `scoped_resources` override (as the README suggests for avoiding N+1s), so the index still fires one COUNT query per record.

`.size` is strictly smarter here: it uses the already-loaded collection or a counter cache when available, and falls back to the same COUNT query otherwise. We've been running this as a view override in production for a while (originally to silence Bullet's counter-cache warnings) — upstreaming it so the override can go away.