### PR TITLE
Add customizable, translatable labels for scope buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,37 @@ end
 
 The new, edit, and delete links are hidden for read-only resources, and any write actions redirect back to the index.
 
+### Scopes
+
+Declare scopes on a resource to render filter buttons on the index page. Each scope must be a scope or class method on the model:
+
+```ruby
+class PostResource < Madmin::Resource
+  scope :published
+  scope :draft
+end
+```
+
+Button labels default to the humanized scope name. To customize or translate them, define an I18n key — `madmin.scopes.<param_key>.<scope>` for one resource, or `madmin.scopes.<scope>` shared across resources:
+
+```yaml
+en:
+  madmin:
+    scopes:
+      post:
+        published: Live
+```
+
+For labels that need logic (e.g. looking up a record name), override `scope_label`:
+
+```ruby
+class PostResource < Madmin::Resource
+  def self.scope_label(name)
+    name.to_s.titleize
+  end
+end
+```
+
 ## Configuring Views
 
 The views packaged within the gem are a great starting point, but inevitably people will need to be able to customize those views.

--- a/app/views/madmin/application/index.html.erb
+++ b/app/views/madmin/application/index.html.erb
@@ -33,7 +33,7 @@
   <% end %>
 
   <% resource.scopes.each do |scope| %>
-    <%= link_to scope.to_s.humanize, resource.index_path(scope: scope, q: params[:q], sort: params[:sort], direction: params[:direction]), class: class_names("btn btn-secondary", {"active" => params[:scope] == scope.to_s}) %>
+    <%= link_to resource.scope_label(scope), resource.index_path(scope: scope, q: params[:q], sort: params[:sort], direction: params[:direction]), class: class_names("btn btn-secondary", {"active" => params[:scope] == scope.to_s}) %>
   <% end %>
 </nav>
 

--- a/lib/madmin/resource.rb
+++ b/lib/madmin/resource.rb
@@ -37,6 +37,13 @@ module Madmin
         scopes << name
       end
 
+      # Label for a scope button on the index. Looks up
+      # madmin.scopes.<param_key>.<name>, then madmin.scopes.<name> in I18n,
+      # falling back to the humanized scope name. Override for custom labels.
+      def scope_label(name)
+        I18n.t("madmin.scopes.#{param_key}.#{name}", default: [:"madmin.scopes.#{name}", name.to_s.humanize])
+      end
+
       def get_attribute(name)
         attributes[name]
       end

--- a/test/madmin/resource_test.rb
+++ b/test/madmin/resource_test.rb
@@ -79,4 +79,32 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal "child_action", MemberActionChildResource.member_actions.last.call
     assert_equal 1, MemberActionChildResource.collection_member_actions.size
   end
+
+  test "scope_label humanizes the scope name by default" do
+    assert_equal "Recently updated", PostResource.scope_label(:recently_updated)
+  end
+
+  test "scope_label uses a resource-specific translation when defined" do
+    I18n.backend.store_translations(:en, madmin: {scopes: {post: {recent: "Fresh"}}})
+    assert_equal "Fresh", PostResource.scope_label(:recent)
+  ensure
+    I18n.reload!
+  end
+
+  test "scope_label falls back to a shared scope translation" do
+    I18n.backend.store_translations(:en, madmin: {scopes: {recent: "Latest"}})
+    assert_equal "Latest", PostResource.scope_label(:recent)
+  ensure
+    I18n.reload!
+  end
+
+  test "scope_label can be overridden per resource" do
+    resource = Class.new(PostResource) do
+      def self.scope_label(name)
+        name.to_s.upcase
+      end
+    end
+
+    assert_equal "RECENT", resource.scope_label(:recent)
+  end
 end


### PR DESCRIPTION
Scope buttons on the index render `scope.to_s.humanize`, hardcoded — a scope can't be renamed, and it's the one index string that can't be translated now that the UI ships locales.

This adds `Resource.scope_label(name)` with a three-step lookup:

1. `madmin.scopes.<param_key>.<name>` — per-resource translation
2. `madmin.scopes.<name>` — shared across resources
3. humanized scope name (current behavior, so nothing changes for existing apps)

It's also overridable per resource for labels that need logic. Real-world case from our app: resources with machine-generated scopes like `route_group_3` (one scope per ferry route group), where the button label comes from a record lookup — without a hook they render as "Route group 3":

```ruby
def self.scope_label(scope)
  id = scope.to_s.delete_prefix(ROUTE_GROUP_SCOPE_PREFIX)
  Ferry::RouteGroup.find_by(id: id)&.name || super
end
```

Includes tests for all three lookup steps plus the override, and a README section documenting scopes (they weren't documented yet) and the new labels.