### PR TITLE
fix: translatable field label in show and index page

### DIFF
--- a/lib/madmin/field.rb
+++ b/lib/madmin/field.rb
@@ -30,7 +30,7 @@ module Madmin
     end
 
     def label
-      options[:label].presence || attribute_name.to_s.titleize
+      options[:label].presence || model.human_attribute_name(attribute_name)
     end
 
     # Used for checking visibility of attribute on an view

--- a/test/madmin/field_test.rb
+++ b/test/madmin/field_test.rb
@@ -61,6 +61,5 @@ class Madmin::FieldTest < ActiveSupport::TestCase
     I18n.with_locale(:"zh-CN") do
       assert_equal "标题", PostResource.attributes[:title].field.label
     end
-
   end
 end

--- a/test/madmin/field_test.rb
+++ b/test/madmin/field_test.rb
@@ -16,7 +16,7 @@ class Madmin::FieldTest < ActiveSupport::TestCase
   end
 
   test "label" do
-    assert_equal "First Name", UserResource.attributes[:first_name].field.label
+    assert_equal "First name", UserResource.attributes[:first_name].field.label
   end
 
   test "label with custom option" do
@@ -36,6 +36,31 @@ class Madmin::FieldTest < ActiveSupport::TestCase
       resource: UserResource,
       options: ActiveSupport::OrderedOptions.new.merge(label: "")
     )
-    assert_equal "Some Attribute", field.label
+    assert_equal "Some attribute", field.label
+  end
+
+  test "label with localize setting" do
+    I18n.backend.store_translations :en, activerecord: {
+      attributes: {
+        post: {
+          title: "En title"
+        }
+      }
+    }
+    I18n.backend.store_translations :"zh-CN", activerecord: {
+      attributes: {
+        post: {
+          title: "标题"
+        }
+      }
+    }
+
+    I18n.with_locale(:en) do
+      assert_equal "En title", PostResource.attributes[:title].field.label
+    end
+    I18n.with_locale(:"zh-CN") do
+      assert_equal "标题", PostResource.attributes[:title].field.label
+    end
+
   end
 end


### PR DESCRIPTION
change
`options[:label].presence || attribute_name.to_s.titleize`
to
`options[:label].presence || model.human_attribute_name(attribute_name)`